### PR TITLE
Net saml changes merged

### DIFF
--- a/lib/XML/Sig.pm
+++ b/lib/XML/Sig.pm
@@ -114,6 +114,7 @@ sub verify {
 
     $self->{ parser } = XML::XPath->new( xml => $xml );
     $self->{ parser }->set_namespace('dsig', 'http://www.w3.org/2000/09/xmldsig#');
+    $self->{ parser }->set_namespace('ec', 'http://www.w3.org/2001/10/xml-exc-c14n#');
 
     my $signature = _trim($self->{parser}->findvalue('//dsig:Signature/dsig:SignatureValue'));
     my $signed_info_node = $self->_get_node('//dsig:Signature/dsig:SignedInfo');

--- a/lib/XML/Sig.pm
+++ b/lib/XML/Sig.pm
@@ -161,8 +161,8 @@ sub verify {
     my $digest = _trim($self->{parser}->findvalue('//dsig:Signature/dsig:SignedInfo/dsig:Reference/dsig:DigestValue'));
     
     my $signed_xml    = $self->_get_signed_xml();
-    my $canonical     = $self->_transform( $signed_xml );
-    my $digest_bin    = sha1( $canonical ); 
+    my $canonical     = $self->_transform($signed_xml, $signature_node);
+    my $digest_bin    = sha1($canonical);
 
     return 1 if ($digest eq _trim(encode_base64($digest_bin)));
     return 0;

--- a/lib/XML/Sig.pm
+++ b/lib/XML/Sig.pm
@@ -157,10 +157,10 @@ sub verify {
             }
     }
 
-    my $digest_method = $self->{parser}->findvalue('//dsig:Signature/dsig:SignedInfo/dsig:Reference/dsig:DigestMethod/@Algorithm');
-    my $digest = _trim($self->{parser}->findvalue('//dsig:Signature/dsig:SignedInfo/dsig:Reference/dsig:DigestValue'));
-    
-    my $signed_xml    = $self->_get_signed_xml();
+    my $digest_method = $self->{parser}->findvalue('dsig:SignedInfo/dsig:Reference/dsig:DigestMethod/@Algorithm', $signature_node);
+    my $digest = _trim($self->{parser}->findvalue('dsig:SignedInfo/dsig:Reference/dsig:DigestValue', $signature_node));
+
+    my $signed_xml    = $self->_get_signed_xml($signature_node);
     my $canonical     = $self->_transform($signed_xml, $signature_node);
     my $digest_bin    = sha1($canonical);
 
@@ -184,7 +184,9 @@ sub _get_xml_to_sign {
 
 sub _get_signed_xml {
     my $self = shift;
-    my $id = $self->{parser}->findvalue('//dsig:Signature/dsig:SignedInfo/dsig:Reference/@URI');
+    my $context = shift;
+
+    my $id = $self->{parser}->findvalue('dsig:SignedInfo/dsig:Reference/@URI', $context);
     $id =~ s/^#//;
     $self->{'sign_id'} = $id;
     my $xpath = "//*[\@ID='$id']";
@@ -355,7 +357,7 @@ sub _transform_env_sig {
     if (defined $self->{dsig_prefix} && length $self->{dsig_prefix}) {
         $prefix = $self->{dsig_prefix} . ':';
     }
-    $str =~ s/(<${prefix}Signature(.*?)>(.*?)\<\/${prefix}Signature>)//igs;
+    $str =~ s/(<${prefix}Signature(.*?)>(.*?)\<\/${prefix}Signature>)//is;
     return $str;
 }
 

--- a/lib/XML/Sig.pm
+++ b/lib/XML/Sig.pm
@@ -17,7 +17,7 @@ use base qw/Exporter/;
 
 use strict;
 
-use Digest::SHA1 qw(sha1 sha1_base64);
+use Digest::SHA qw(sha1 sha1_base64);
 use XML::XPath;
 use MIME::Base64;
 use Carp;
@@ -749,7 +749,7 @@ Now, let's insert a signature:
 
 =over
 
-=item L<Digest::SHA1>
+=item L<Digest::SHA>
 
 =item L<XML::XPath>
 

--- a/lib/XML/Sig.pm
+++ b/lib/XML/Sig.pm
@@ -114,11 +114,9 @@ sub verify {
 
     $self->{ parser } = XML::XPath->new( xml => $xml );
     $self->{ parser }->set_namespace('dsig', 'http://www.w3.org/2000/09/xmldsig#');
-    # TODO: Find a more elegant way to match /samlp:Response/dsig:Signature
-    $self->{ parser }->set_namespace('samlp', 'urn:oasis:names:tc:SAML:2.0:protocol');
+    $self->{ parser }->set_namespace('ec', 'http://www.w3.org/2001/10/xml-exc-c14n#');
 
-    my $signature_nodeset = $self->{parser}->findnodes('/samlp:Response/dsig:Signature');
-    my $signature_node = $signature_nodeset->shift();
+    my $signature_nodeset = $self->{parser}->findnodes('//dsig:Signature');
 
     my $value = $self->{parser}->findvalue('dsig:SignatureValue', $signature_node);
 
@@ -556,7 +554,7 @@ sub _signedinfo_xml {
     my $self = shift;
     my ($digest_xml) = @_;
 
-    return qq{<dsig:SignedInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#">
+    return qq{<dsig:SignedInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#">
                 <dsig:CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments" />
                 <dsig:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#$self->{key_type}-sha1" />
                 $digest_xml

--- a/lib/XML/Sig.pm
+++ b/lib/XML/Sig.pm
@@ -192,15 +192,39 @@ sub _get_signed_xml {
 
 sub _transform {
     my $self = shift;
-    my ($xml) = @_;
-    foreach my $node ($self->{parser}->find('//dsig:Transform/@Algorithm')->get_nodelist) {
-        my $alg = $node->getNodeValue;
-        if ($alg eq TRANSFORM_ENV_SIG) { $xml = $self->_transform_env_sig($xml); }
-        elsif ($alg eq TRANSFORM_EXC_C14N) { $xml = $self->_canonicalize_xml($xml,0); }
-        elsif ($alg eq TRANSFORM_EXC_C14N_COMMENTS) { $xml = $self->_canonicalize_xml($xml,1); }
-        else { die "Unsupported transform: $alg"; }
+    my ($xml, $context) = @_;
+
+    my $transforms = $self->{parser}->find(
+        'dsig:SignedInfo/dsig:Reference/dsig:Transforms/dsig:Transform', 
+        $context
+    );
+
+    foreach my $node ($transforms->get_nodelist) {
+        my $alg = $node->getAttribute('Algorithm');
+
+        if ($alg eq TRANSFORM_ENV_SIG) {
+            $xml = $self->_transform_env_sig($xml);
+        }
+        elsif ($alg eq TRANSFORM_EXC_C14N) {
+            my $prefixlist = $self->_find_prefixlist($node);
+            $xml = $self->_canonicalize_xml($xml, 0, $prefixlist);
+        }
+        elsif ($alg eq TRANSFORM_EXC_C14N_COMMENTS) {
+            my $prefixlist = $self->_find_prefixlist($node);
+            $xml = $self->_canonicalize_xml($xml, 1, $prefixlist);
+        }
+        else {
+            die "Unsupported transform: $alg";
+        }
     }
     return $xml;
+}
+
+sub _find_prefixlist {
+    my $self = shift;
+    my ($node) = @_;
+    my $prefixlist = $self->{parser}->findvalue('ec:InclusiveNamespaces/@PrefixList', $node);
+    return $prefixlist;
 }
 
 sub _verify_rsa {
@@ -573,18 +597,27 @@ sub _reference_xml {
 
 sub _canonicalize_xml {
     my $self = shift;
-    my ($xml,$comments) = @_;
+    my ($xml,$comments,$prefixlist) = @_;
     $comments = 0 unless $comments;
+    $prefixlist = '' unless $prefixlist;
 
     if ( $self->{canonicalizer} eq 'XML::Canonical' ) {
         require XML::Canonical;
+
+        # XML::Canonical doesn't support a prefix list, so
+        # InclusiveNamespaces will have no effect
+
         my $xmlcanon = XML::Canonical->new( comments => $comments );
         return $xmlcanon->canonicalize_string( $xml );
     }
     elsif ( $self->{ canonicalizer } eq 'XML::CanonicalizeXML' ) {
         require XML::CanonicalizeXML;
         my $xpath = '<XPath>(//. | //@* | //namespace::*)</XPath>';
-        return XML::CanonicalizeXML::canonicalize( $xml, $xpath, [], 1, $comments );
+
+        # adjust prefixlist from attribute for XML::CanonicalizeXML's format
+        $prefixlist =~ s/ /,/g;
+
+        return XML::CanonicalizeXML::canonicalize( $xml, $xpath, $prefixlist, 1, $comments );
     }
     else {
         confess "Unknown XML canonicalizer module.";

--- a/lib/XML/Sig.pm
+++ b/lib/XML/Sig.pm
@@ -114,10 +114,10 @@ sub verify {
 
     $self->{ parser } = XML::XPath->new( xml => $xml );
     $self->{ parser }->set_namespace('dsig', 'http://www.w3.org/2000/09/xmldsig#');
-    # TODO: Find a more elegant way to match /saml2p:Response/dsig:Signature
-    $self->{ parser }->set_namespace('saml2p', 'urn:oasis:names:tc:SAML:2.0:protocol');
+    # TODO: Find a more elegant way to match /samlp:Response/dsig:Signature
+    $self->{ parser }->set_namespace('samlp', 'urn:oasis:names:tc:SAML:2.0:protocol');
 
-    my $signature_nodeset = $self->{parser}->findnodes('/saml2p:Response/dsig:Signature');
+    my $signature_nodeset = $self->{parser}->findnodes('/samlp:Response/dsig:Signature');
     my $signature_node = $signature_nodeset->shift();
 
     my $value = $self->{parser}->findvalue('dsig:SignatureValue', $signature_node);

--- a/lib/XML/Sig.pm
+++ b/lib/XML/Sig.pm
@@ -7,7 +7,7 @@ use warnings;
 use vars qw($VERSION @EXPORT_OK %EXPORT_TAGS $DEBUG);
 
 $DEBUG = 0;
-$VERSION = '0.23';
+$VERSION = '0.23_01';
 
 use base qw(Class::Accessor);
 XML::Sig->mk_accessors(qw(canonicalizer key));

--- a/lib/XML/Sig.pm
+++ b/lib/XML/Sig.pm
@@ -114,80 +114,57 @@ sub verify {
 
     $self->{ parser } = XML::XPath->new( xml => $xml );
     $self->{ parser }->set_namespace('dsig', 'http://www.w3.org/2000/09/xmldsig#');
-    $self->{ parser }->set_namespace('ec', 'http://www.w3.org/2001/10/xml-exc-c14n#');
 
-    my $signature_nodeset = $self->{parser}->findnodes('//dsig:Signature');
+    my $signature = _trim($self->{parser}->findvalue('//dsig:Signature/dsig:SignatureValue'));
+    my $signed_info_node = $self->_get_node('//dsig:Signature/dsig:SignedInfo');
 
-    while (my $signature_node = $signature_nodeset->shift()) {
-
-        my $value = $self->{parser}->findvalue('dsig:SignatureValue', $signature_node);
-
-        my $signature = _trim($self->{parser}->findvalue('dsig:SignatureValue', $signature_node));
-        my $signed_info_node = $self->_get_node('dsig:SignedInfo', $signature_node);
-
-        my $ns;
-        if (defined $signature_node && ref $signature_node) {
+    my $signature_node = $self->_get_node('//dsig:Signature');
+    my $ns;
+    if (defined $signature_node && ref $signature_node) {
             $ns = $signature_node->getNamespaces->[0];
             $self->{dsig_prefix} = ($ns->getPrefix eq '#default') ? '' : $ns->getPrefix;
-        }
-        else {
+    }
+    else {
             die "no Signature node?";
-        }
-    
-        if (scalar @{ $signed_info_node->getNamespaces } == 0) {
-            $signed_info_node->appendNamespace($ns);
-        }
-    
-        my $signed_info = XML::XPath::XMLParser::as_string($signed_info_node);
-        my $signed_info_canon = $self->_canonicalize_xml( $signed_info );
-
-        if (defined $self->{cert_obj}) {
-            # use the provided cert to verify
-            unless ($self->_verify_x509_cert($self->{cert_obj},$signed_info_canon,$signature)) {
-                print STDERR "not verified by x509\n";
-                return 0;
-            }
-        }
-        else {
-            # extract the certficate or key from the document
-            my $keyinfo_nodeset;
-            if ($keyinfo_nodeset = $self->{parser}->findnodes('dsig:KeyInfo/dsig:X509Data', $signature_node)) {
-                my $keyinfo_node = $keyinfo_nodeset->shift();
-                unless ($self->_verify_x509($keyinfo_node,$signed_info_canon,$signature)) {
-                    print STDERR "not verified by x509\n";
-                    return 0;
-                }
-            }
-            elsif ($keyinfo_nodeset = $self->{parser}->find('dsig:KeyInfo/dsig:KeyValue/dsig:RSAKeyValue', $signature_node)) {
-                my $keyinfo_node = $keyinfo_nodeset->shift();
-                unless ($self->_verify_rsa($keyinfo_node,$signed_info_canon,$signature)) {
-                    print STDERR "not verified by rsa\n";
-                    return 0;
-                }
-            }
-            elsif ($keyinfo_nodeset = $self->{parser}->find('dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue', $signature_node)) {
-                my $keyinfo_node = $keyinfo_nodeset->shift();
-                unless ($self->_verify_dsa($keyinfo_node,$signed_info_canon,$signature)) {
-                    print STDERR "not verified by dsa\n";
-                    return 0;
-                }
-            }
-            else {
-                die "Unrecognized key type or no KeyInfo in document";
-            }
-        }
-
-        my $digest_method = $self->{parser}->findvalue('dsig:Reference/dsig:DigestMethod/@Algorithm', $signed_info_node);
-        my $refdigest     = _trim($self->{parser}->findvalue('dsig:Reference/dsig:DigestValue', $signed_info_node));
-    
-        my $signed_xml    = $self->_get_signed_xml( $signature_node );
-        my $canonical     = $self->_transform( $signed_xml, $signature_node );
-        my $digest        = encode_base64(_trim(sha1( $canonical )), '');
-
-        return 0 unless ($digest eq $refdigest);
     }
     
-    return 1;
+    if (scalar @{ $signed_info_node->getNamespaces } == 0) {
+        $signed_info_node->appendNamespace($ns);
+    }
+    
+    my $signed_info = XML::XPath::XMLParser::as_string($signed_info_node);
+    my $signed_info_canon = $self->_canonicalize_xml( $signed_info );
+
+    if (defined $self->{cert_obj}) {
+            # use the provided cert to verify
+            return 0 unless $self->_verify_x509_cert($self->{cert_obj},$signed_info_canon,$signature);
+    }
+    else {
+            # extract the certficate or key from the document
+            my $keyinfo_node;
+            if ($keyinfo_node = $self->{parser}->find('//dsig:Signature/dsig:KeyInfo/dsig:X509Data')) {
+                    return 0 unless $self->_verify_x509($keyinfo_node,$signed_info_canon,$signature);
+            } 
+            elsif ($keyinfo_node = $self->{parser}->find('//dsig:Signature/dsig:KeyInfo/dsig:KeyValue/dsig:RSAKeyValue')) {
+                    return 0 unless $self->_verify_rsa($keyinfo_node,$signed_info_canon,$signature);
+            }
+            elsif ($keyinfo_node = $self->{parser}->find('//dsig:Signature/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue')) {
+                    return 0 unless $self->_verify_dsa($keyinfo_node,$signed_info_canon,$signature);
+            }
+            else {
+                    die "Unrecognized key type or no KeyInfo in document";
+            }
+    }
+
+    my $digest_method = $self->{parser}->findvalue('//dsig:Signature/dsig:SignedInfo/dsig:Reference/dsig:DigestMethod/@Algorithm');
+    my $digest = _trim($self->{parser}->findvalue('//dsig:Signature/dsig:SignedInfo/dsig:Reference/dsig:DigestValue'));
+    
+    my $signed_xml    = $self->_get_signed_xml();
+    my $canonical     = $self->_transform( $signed_xml );
+    my $digest_bin    = sha1( $canonical ); 
+
+    return 1 if ($digest eq _trim(encode_base64($digest_bin)));
+    return 0;
 }
 
 sub signer_cert {
@@ -206,8 +183,7 @@ sub _get_xml_to_sign {
 
 sub _get_signed_xml {
     my $self = shift;
-    my ($context) = @_;
-    my $id = $self->{parser}->findvalue('dsig:SignedInfo/dsig:Reference/@URI', $context);
+    my $id = $self->{parser}->findvalue('//dsig:Signature/dsig:SignedInfo/dsig:Reference/@URI');
     $id =~ s/^#//;
     $self->{'sign_id'} = $id;
     my $xpath = "//*[\@ID='$id']";
@@ -216,39 +192,15 @@ sub _get_signed_xml {
 
 sub _transform {
     my $self = shift;
-    my ($xml, $context) = @_;
-
-    my $transforms = $self->{parser}->find(
-        'dsig:SignedInfo/dsig:Reference/dsig:Transforms/dsig:Transform', 
-        $context
-    );
-
-    foreach my $node ($transforms->get_nodelist) {
-        my $alg = $node->getAttribute('Algorithm');
-
-        if ($alg eq TRANSFORM_ENV_SIG) {
-            $xml = $self->_transform_env_sig($xml);
-        }
-        elsif ($alg eq TRANSFORM_EXC_C14N) {
-            my $prefixlist = $self->_find_prefixlist($node);
-            $xml = $self->_canonicalize_xml($xml, 0, $prefixlist);
-        }
-        elsif ($alg eq TRANSFORM_EXC_C14N_COMMENTS) {
-            my $prefixlist = $self->_find_prefixlist($node);
-            $xml = $self->_canonicalize_xml($xml, 1, $prefixlist);
-        }
-        else {
-            die "Unsupported transform: $alg";
-        }
+    my ($xml) = @_;
+    foreach my $node ($self->{parser}->find('//dsig:Transform/@Algorithm')->get_nodelist) {
+        my $alg = $node->getNodeValue;
+        if ($alg eq TRANSFORM_ENV_SIG) { $xml = $self->_transform_env_sig($xml); }
+        elsif ($alg eq TRANSFORM_EXC_C14N) { $xml = $self->_canonicalize_xml($xml,0); }
+        elsif ($alg eq TRANSFORM_EXC_C14N_COMMENTS) { $xml = $self->_canonicalize_xml($xml,1); }
+        else { die "Unsupported transform: $alg"; }
     }
     return $xml;
-}
-
-sub _find_prefixlist {
-    my $self = shift;
-    my ($node) = @_;
-    my $prefixlist = $self->{parser}->findvalue('ec:InclusiveNamespaces/@PrefixList', $node);
-    return $prefixlist;
 }
 
 sub _verify_rsa {
@@ -256,9 +208,9 @@ sub _verify_rsa {
     my ($context,$canonical,$sig) = @_;
 
     # Generate Public Key from XML
-    my $mod = _trim($self->{parser}->findvalue('dsig:Modulus', $context));
+    my $mod = _trim($self->{parser}->findvalue('//dsig:Signature/dsig:KeyInfo/dsig:KeyValue/dsig:RSAKeyValue/dsig:Modulus'));
     my $modBin = decode_base64( $mod );
-    my $exp = _trim($self->{parser}->findvalue('dsig:Exponent', $context));
+    my $exp = _trim($self->{parser}->findvalue('//dsig:Signature/dsig:KeyInfo/dsig:KeyValue/dsig:RSAKeyValue/dsig:Exponent'));
     my $expBin = decode_base64( $exp );
     my $n = Crypt::OpenSSL::Bignum->new_from_bin($modBin);
     my $e = Crypt::OpenSSL::Bignum->new_from_bin($expBin);
@@ -273,6 +225,19 @@ sub _verify_rsa {
 sub _clean_x509 {
     my $self = shift;
     my ($cert) = @_;
+
+    # rewrap the base64 data from the certificate; it may not be
+    # wrapped at 64 characters as PEM requires
+    $cert =~ s/\n//g;
+    
+    my @lines;
+    while (length $cert > 64) {
+            push @lines, substr $cert, 0, 64, '';
+        }
+    push @lines, $cert;
+    
+    $cert = join "\n", @lines;
+
     $cert = "-----BEGIN CERTIFICATE-----\n" . $cert . "\n-----END CERTIFICATE-----\n";
     return $cert;
 }
@@ -287,12 +252,12 @@ sub _verify_x509 {
     confess "Crypt::OpenSSL::X509 needs to be installed so that we can handle X509 certificates" if $@;
 
     # Generate Public Key from XML
-    my $certificate = _trim($self->{parser}->findvalue('dsig:X509Certificate', $context));
+    my $certificate = _trim($self->{parser}->findvalue('//dsig:Signature/dsig:KeyInfo/dsig:X509Data/dsig:X509Certificate'));
 
     # This is added because the X509 parser requires it for self-identification
     $certificate = $self->_clean_x509($certificate);
-    my $cert = Crypt::OpenSSL::X509->new_from_string($certificate);
 
+    my $cert = Crypt::OpenSSL::X509->new_from_string($certificate);
     return $self->_verify_x509_cert($cert, $canonical, $sig);
 }
 
@@ -327,10 +292,10 @@ sub _verify_dsa {
     };
 
     # Generate Public Key from XML
-    my $p = decode_base64(_trim($self->{parser}->findvalue('dsig:P', $context)));
-    my $q = decode_base64(_trim($self->{parser}->findvalue('dsig:Q', $context)));
-    my $g = decode_base64(_trim($self->{parser}->findvalue('dsig:G', $context)));
-    my $y = decode_base64(_trim($self->{parser}->findvalue('dsig:Y', $context)));
+    my $p = decode_base64(_trim($self->{parser}->findvalue('//dsig:Signature/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue/dsig:P')));
+    my $q = decode_base64(_trim($self->{parser}->findvalue('//dsig:Signature/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue/dsig:Q')));
+    my $g = decode_base64(_trim($self->{parser}->findvalue('//dsig:Signature/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue/dsig:G')));
+    my $y = decode_base64(_trim($self->{parser}->findvalue('//dsig:Signature/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue/dsig:Y')));
     my $dsa_pub = Crypt::OpenSSL::DSA->new();
     $dsa_pub->set_p($p);
     $dsa_pub->set_q($q);
@@ -346,13 +311,8 @@ sub _verify_dsa {
 
 sub _get_node {
     my $self = shift;
-    my ($xpath, $context) = @_;
-    my $nodeset;
-    if ($context) {
-         $nodeset = $self->{parser}->find($xpath, $context);
-    } else {
-         $nodeset = $self->{parser}->find($xpath);
-    }
+    my ($xpath) = @_;
+    my $nodeset = $self->{parser}->find($xpath);
     foreach my $node ($nodeset->get_nodelist) {
         return $node; 
     }
@@ -370,11 +330,7 @@ sub _transform_env_sig {
     if (defined $self->{dsig_prefix} && length $self->{dsig_prefix}) {
         $prefix = $self->{dsig_prefix} . ':';
     }
-    # This removes the first Signature tag from the XML - even if there is another XML tree with another Signature inside and that comes first.
-    # TODO: Remove the outermost Signature only.
-
-    $str =~ s/(<${prefix}Signature(.*?)>(.*?)\<\/${prefix}Signature>)//is;
-
+    $str =~ s/(<${prefix}Signature(.*?)>(.*?)\<\/${prefix}Signature>)//igs;
     return $str;
 }
 
@@ -594,7 +550,7 @@ sub _signedinfo_xml {
     my $self = shift;
     my ($digest_xml) = @_;
 
-    return qq{<dsig:SignedInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#">
+    return qq{<dsig:SignedInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#">
                 <dsig:CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments" />
                 <dsig:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#$self->{key_type}-sha1" />
                 $digest_xml
@@ -617,26 +573,18 @@ sub _reference_xml {
 
 sub _canonicalize_xml {
     my $self = shift;
-    my ($xml,$comments,$prefixlist) = @_;
+    my ($xml,$comments) = @_;
     $comments = 0 unless $comments;
-    $prefixlist = '' unless $prefixlist;
 
     if ( $self->{canonicalizer} eq 'XML::Canonical' ) {
         require XML::Canonical;
-
-        # TODO - pass prefixlist in here if X::C supports it
-
         my $xmlcanon = XML::Canonical->new( comments => $comments );
         return $xmlcanon->canonicalize_string( $xml );
     }
     elsif ( $self->{ canonicalizer } eq 'XML::CanonicalizeXML' ) {
         require XML::CanonicalizeXML;
         my $xpath = '<XPath>(//. | //@* | //namespace::*)</XPath>';
-
-        # adjust prefixlist from attribute for XML::CanonicalizeXML's format
-        $prefixlist =~ s/ /,/g;
-
-        return XML::CanonicalizeXML::canonicalize( $xml, $xpath, $prefixlist, 1, $comments );
+        return XML::CanonicalizeXML::canonicalize( $xml, $xpath, [], 1, $comments );
     }
     else {
         confess "Unknown XML canonicalizer module.";

--- a/lib/XML/Sig.pm
+++ b/lib/XML/Sig.pm
@@ -111,7 +111,7 @@ sub sign {
 sub verify {
     my $self = shift;
     delete $self->{signer_cert};
-    
+
     my ($xml) = @_;
 
     $self->{ parser } = XML::XPath->new( xml => $xml );
@@ -135,11 +135,11 @@ sub verify {
         else {
             die "no Signature node?";
         }
-    
+
         if (scalar @{ $signed_info_node->getNamespaces } == 0) {
             $signed_info_node->appendNamespace($ns);
         }
-    
+
         my $signed_info = XML::XPath::XMLParser::as_string($signed_info_node);
         my $signed_info_canon = $self->_canonicalize_xml( $signed_info );
         my $digest_method = $self->{parser}->findvalue('dsig:SignedInfo/dsig:Reference/dsig:DigestMethod/@Algorithm', $signature_node);
@@ -186,7 +186,7 @@ sub verify {
 
         #my $digest_method = $self->{parser}->findvalue('dsig:Reference/dsig:DigestMethod/@Algorithm', $signed_info_node);
         my $refdigest     = _trim($self->{parser}->findvalue('dsig:Reference/dsig:DigestValue', $signed_info_node));
-    
+
         my $signed_xml    = $self->_get_signed_xml( $signature_node );
         my $canonical     = $self->_transform( $signed_xml, $signature_node );
         my $digest    = $self->{digest_method}->($canonical);
@@ -226,7 +226,7 @@ sub _transform {
     my ($xml, $context) = @_;
 
     my $transforms = $self->{parser}->find(
-        'dsig:SignedInfo/dsig:Reference/dsig:Transforms/dsig:Transform', 
+        'dsig:SignedInfo/dsig:Reference/dsig:Transforms/dsig:Transform',
         $context
     );
 
@@ -287,13 +287,13 @@ sub _clean_x509 {
     # rewrap the base64 data from the certificate; it may not be
     # wrapped at 64 characters as PEM requires
     $cert =~ s/\n//g;
-    
+
     my @lines;
     while (length $cert > 64) {
             push @lines, substr $cert, 0, 64, '';
         }
     push @lines, $cert;
-    
+
     $cert = join "\n", @lines;
 
     $cert = "-----BEGIN CERTIFICATE-----\n" . $cert . "\n-----END CERTIFICATE-----\n";
@@ -379,7 +379,7 @@ sub _get_node {
          $nodeset = $self->{parser}->find($xpath);
     }
     foreach my $node ($nodeset->get_nodelist) {
-        return $node; 
+        return $node;
     }
 }
 
@@ -467,7 +467,7 @@ sub _load_rsa_key {
             my $bigNum = ( $rsaKey->get_key_parameters() )[1];
             my $bin = $bigNum->to_bin();
             my $exp = encode_base64( $bin, '' );
-            
+
             $bigNum = ( $rsaKey->get_key_parameters() )[0];
             $bin = $bigNum->to_bin();
             my $mod = encode_base64( $bin, '' );
@@ -526,7 +526,7 @@ sub _load_cert_file {
         local $/ = undef;
         $text = <$CERT>;
         close $CERT;
-        
+
         my $cert = Crypt::OpenSSL::X509->new_from_string($text);
         if ( $cert ) {
             $self->{ cert_obj } = $cert;
@@ -682,31 +682,31 @@ XML::Sig - A toolkit to help sign and verify XML Digital Signatures.
      canonicalizer => 'XML::CanonicalizeXML',
      key => 'path/to/private.key',
    });
-   
+
    # create a signature
    my $signed = $signer->sign($xml);
    print "Signed XML: $signed\n";
-   
+
    # verify a signature
-   $signer->verify($signed) 
+   $signer->verify($signed)
      or die "Signature Invalid.";
    print "Signature valid.\n";
 
 =head1 DESCRIPTION
 
 This perl module provides two primary capabilities: given an XML string, create
-and insert a digital signature, or if one is already present in the string verify 
+and insert a digital signature, or if one is already present in the string verify
 it -- all in accordance with the W3C standard governing XML signatures.
 
 =head1 ABOUT DIGITAL SIGNATURES
 
 Just as one might want to send an email message that is cryptographically signed
 in order to give the recipient the means to independently verify who sent the email,
-one might also want to sign an XML document. This is especially true in the 
-scenario where an XML document is received in an otherwise unauthenticated 
+one might also want to sign an XML document. This is especially true in the
+scenario where an XML document is received in an otherwise unauthenticated
 context, e.g. SAML.
 
-However XML provides a challenge that email does not. In XML, two documents can be 
+However XML provides a challenge that email does not. In XML, two documents can be
 byte-wise inequivalent, and semanticaly equivalent at the same time. For example:
 
     <?xml version="1.0"?>
@@ -722,16 +722,16 @@ byte-wise inequivalent, and semanticaly equivalent at the same time. For example
     </foo>
 
 Each of these document express the same thing, or in other words they "mean"
-the same thing. However if you were to strictly sign the raw text of these 
-documents, they would each produce different signatures. 
+the same thing. However if you were to strictly sign the raw text of these
+documents, they would each produce different signatures.
 
-XML Signatures on the other hand will produce the same signature for each of 
-the documents above. Therefore an XML document can be written and rewritten by 
-different parties and still be able to have someone at the end of the line 
+XML Signatures on the other hand will produce the same signature for each of
+the documents above. Therefore an XML document can be written and rewritten by
+different parties and still be able to have someone at the end of the line
 verify a signature the document may contain.
 
 There is a specially subscribed methodology for how this process should be
-executed and involves transforming the XML into its canonical form so a 
+executed and involves transforming the XML into its canonical form so a
 signature can be reliably inserted or extracted for verification. This
 module implements that process.
 
@@ -810,7 +810,7 @@ Now, let's insert a signature:
 
 This module supports the following signature methods:
 
-=over 
+=over
 
 =item DSA
 
@@ -822,7 +822,7 @@ This module supports the following signature methods:
 
 This module supports the following canonicalization methods and transforms:
 
-=over 
+=over
 
 =item EXC-X14N#
 
@@ -845,7 +845,7 @@ Constructor; see OPTIONS below.
 =item B<sign($xml)>
 
 When given a string of XML, it will return the same string with a signature
-generated from the key provided when the XML::Sig object was initialized. 
+generated from the key provided when the XML::Sig object was initialized.
 
 This method presumes that there is one and only one element in your XML
 document with an ID (case sensitive) attribute. This is the element that will
@@ -855,7 +855,7 @@ attribute can be found on an element, the signature will not be created.
 
 =item B<verify($xml)>
 
-Returns true or false based upon whether the signature is valid or not. 
+Returns true or false based upon whether the signature is valid or not.
 
 When using XML::Sig exclusively to verify a signature, no key needs to be
 specified during initialization given that the public key should be
@@ -922,8 +922,8 @@ L<http://github.com/byrnereese/perl-XML-Sig>
 
 Author: Byrne Reese <byrne@majordojo.com>
 
-Thanks to Manni Heumann who wrote Google::SAML::Response from 
-which this module borrows heavily in order to create digital 
+Thanks to Manni Heumann who wrote Google::SAML::Response from
+which this module borrows heavily in order to create digital
 signatures.
 
 Net::SAML2 embedded version amended by Chris Andrews <chris@nodnol.org>.

--- a/lib/XML/Sig.pm
+++ b/lib/XML/Sig.pm
@@ -7,7 +7,7 @@ use warnings;
 use vars qw($VERSION @EXPORT_OK %EXPORT_TAGS $DEBUG);
 
 $DEBUG = 0;
-$VERSION = '0.23_01';
+$VERSION = '0.23_02';
 
 use base qw(Class::Accessor);
 XML::Sig->mk_accessors(qw(canonicalizer key));
@@ -190,7 +190,7 @@ sub verify {
         my $signed_xml    = $self->_get_signed_xml( $signature_node );
         my $canonical     = $self->_transform( $signed_xml, $signature_node );
         my $digest    = $self->{digest_method}->($canonical);
-        return 0 unless ($refdigest eq _trim(encode_base64($digest)));
+        return 0 unless ($refdigest eq _trim(encode_base64($digest, '')));
     }
     
     return 1;

--- a/lib/XML/Sig.pm
+++ b/lib/XML/Sig.pm
@@ -46,16 +46,16 @@ sub new {
     }
     bless $self, $class;
     $self->{ 'canonicalizer' } =
-	exists $params->{ canonicalizer } ? $params->{ canonicalizer } : 'XML::CanonicalizeXML';
+        exists $params->{ canonicalizer } ? $params->{ canonicalizer } : 'XML::CanonicalizeXML';
     $self->{ 'x509' } = exists $params->{ x509 } ? 1 : 0;
     if ( exists $params->{ 'key' } ) {
-	$self->_load_key( $params->{ 'key' } );
+        $self->_load_key( $params->{ 'key' } );
     }
     if ( exists $params->{ 'cert' } ) {
-	$self->_load_cert_file( $params->{ 'cert' } );
+        $self->_load_cert_file( $params->{ 'cert' } );
     }
     if ( exists $params->{ 'cert_text' } ) {
-	$self->_load_cert_text( $params->{ 'cert_text' } );
+        $self->_load_cert_text( $params->{ 'cert_text' } );
     }
     return $self;
 }
@@ -88,12 +88,12 @@ sub sign {
 
     my $signature;
     if ($self->{key_type} eq 'dsa') {
-	# DSA only permits the signing of 20 bytes or less, hence the sha1
-	my $bin_signature  = $self->{key_obj}->sign( sha1($canonical) );
-	$signature     = encode_base64( $bin_signature, "\n" );
+        # DSA only permits the signing of 20 bytes or less, hence the sha1
+        my $bin_signature  = $self->{key_obj}->sign( sha1($canonical) );
+        $signature     = encode_base64( $bin_signature, "\n" );
     } else {
-	my $bin_signature = $self->{key_obj}->sign( $canonical );
-	$signature     = encode_base64( $bin_signature, "\n" );
+        my $bin_signature = $self->{key_obj}->sign( $canonical );
+        $signature     = encode_base64( $bin_signature, "\n" );
     }
 
     # With the signature value and the signedinfo element, we create
@@ -121,39 +121,39 @@ sub verify {
     my $signature_node = $self->_get_node('//dsig:Signature');
     my $ns;
     if (defined $signature_node && ref $signature_node) {
-	    $ns = $signature_node->getNamespaces->[0];
-	    $self->{dsig_prefix} = ($ns->getPrefix eq '#default') ? '' : $ns->getPrefix;
+            $ns = $signature_node->getNamespaces->[0];
+            $self->{dsig_prefix} = ($ns->getPrefix eq '#default') ? '' : $ns->getPrefix;
     }
     else {
-	    die "no Signature node?";
+            die "no Signature node?";
     }
     
     if (scalar @{ $signed_info_node->getNamespaces } == 0) {
-	$signed_info_node->appendNamespace($ns);
+        $signed_info_node->appendNamespace($ns);
     }
     
     my $signed_info = XML::XPath::XMLParser::as_string($signed_info_node);
     my $signed_info_canon = $self->_canonicalize_xml( $signed_info );
 
     if (defined $self->{cert_obj}) {
-	    # use the provided cert to verify
-	    return 0 unless $self->_verify_x509_cert($self->{cert_obj},$signed_info_canon,$signature);
+            # use the provided cert to verify
+            return 0 unless $self->_verify_x509_cert($self->{cert_obj},$signed_info_canon,$signature);
     }
     else {
-	    # extract the certficate or key from the document
-	    my $keyinfo_node;
-	    if ($keyinfo_node = $self->{parser}->find('//dsig:Signature/dsig:KeyInfo/dsig:X509Data')) {
-		    return 0 unless $self->_verify_x509($keyinfo_node,$signed_info_canon,$signature);
-	    } 
-	    elsif ($keyinfo_node = $self->{parser}->find('//dsig:Signature/dsig:KeyInfo/dsig:KeyValue/dsig:RSAKeyValue')) {
-		    return 0 unless $self->_verify_rsa($keyinfo_node,$signed_info_canon,$signature);
-	    }
-	    elsif ($keyinfo_node = $self->{parser}->find('//dsig:Signature/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue')) {
-		    return 0 unless $self->_verify_dsa($keyinfo_node,$signed_info_canon,$signature);
-	    }
-	    else {
-		    die "Unrecognized key type or no KeyInfo in document";
-	    }
+            # extract the certficate or key from the document
+            my $keyinfo_node;
+            if ($keyinfo_node = $self->{parser}->find('//dsig:Signature/dsig:KeyInfo/dsig:X509Data')) {
+                    return 0 unless $self->_verify_x509($keyinfo_node,$signed_info_canon,$signature);
+            } 
+            elsif ($keyinfo_node = $self->{parser}->find('//dsig:Signature/dsig:KeyInfo/dsig:KeyValue/dsig:RSAKeyValue')) {
+                    return 0 unless $self->_verify_rsa($keyinfo_node,$signed_info_canon,$signature);
+            }
+            elsif ($keyinfo_node = $self->{parser}->find('//dsig:Signature/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue')) {
+                    return 0 unless $self->_verify_dsa($keyinfo_node,$signed_info_canon,$signature);
+            }
+            else {
+                    die "Unrecognized key type or no KeyInfo in document";
+            }
     }
 
     my $digest_method = $self->{parser}->findvalue('//dsig:Signature/dsig:SignedInfo/dsig:Reference/dsig:DigestMethod/@Algorithm');
@@ -194,11 +194,11 @@ sub _transform {
     my $self = shift;
     my ($xml) = @_;
     foreach my $node ($self->{parser}->find('//dsig:Transform/@Algorithm')->get_nodelist) {
-	my $alg = $node->getNodeValue;
-	if ($alg eq TRANSFORM_ENV_SIG) { $xml = $self->_transform_env_sig($xml); }
-	elsif ($alg eq TRANSFORM_EXC_C14N) { $xml = $self->_canonicalize_xml($xml,0); }
-	elsif ($alg eq TRANSFORM_EXC_C14N_COMMENTS) { $xml = $self->_canonicalize_xml($xml,1); }
-	else { die "Unsupported transform: $alg"; }
+        my $alg = $node->getNodeValue;
+        if ($alg eq TRANSFORM_ENV_SIG) { $xml = $self->_transform_env_sig($xml); }
+        elsif ($alg eq TRANSFORM_EXC_C14N) { $xml = $self->_canonicalize_xml($xml,0); }
+        elsif ($alg eq TRANSFORM_EXC_C14N_COMMENTS) { $xml = $self->_canonicalize_xml($xml,1); }
+        else { die "Unsupported transform: $alg"; }
     }
     return $xml;
 }
@@ -380,15 +380,15 @@ sub _load_rsa_key {
         $self->{ key_obj }  = $rsaKey;
         $self->{ key_type } = 'rsa';
 
-	if (!$self->{ x509 }) {
-	    my $bigNum = ( $rsaKey->get_key_parameters() )[1];
-	    my $bin = $bigNum->to_bin();
-	    my $exp = encode_base64( $bin, '' );
-	    
-	    $bigNum = ( $rsaKey->get_key_parameters() )[0];
-	    $bin = $bigNum->to_bin();
-	    my $mod = encode_base64( $bin, '' );
-	    $self->{KeyInfo} = "<dsig:KeyInfo>
+        if (!$self->{ x509 }) {
+            my $bigNum = ( $rsaKey->get_key_parameters() )[1];
+            my $bin = $bigNum->to_bin();
+            my $exp = encode_base64( $bin, '' );
+            
+            $bigNum = ( $rsaKey->get_key_parameters() )[0];
+            $bin = $bigNum->to_bin();
+            my $mod = encode_base64( $bin, '' );
+            $self->{KeyInfo} = "<dsig:KeyInfo>
                                  <dsig:KeyValue>
                                   <dsig:RSAKeyValue>
                                    <dsig:Modulus>$mod</dsig:Modulus>
@@ -396,7 +396,7 @@ sub _load_rsa_key {
                                   </dsig:RSAKeyValue>
                                  </dsig:KeyValue>
                                 </dsig:KeyInfo>";
-	}
+        }
     }
     else {
         confess "did not get a new Crypt::OpenSSL::RSA object";
@@ -432,7 +432,7 @@ sub _load_cert_file {
     my $self = shift;
 
     eval {
-	require Crypt::OpenSSL::X509;
+        require Crypt::OpenSSL::X509;
     };
 
     confess "Crypt::OpenSSL::X509 needs to be installed so that we can handle X509 certs." if $@;
@@ -448,8 +448,8 @@ sub _load_cert_file {
         if ( $cert ) {
             $self->{ cert_obj } = $cert;
             my $cert_text = $cert->as_string;
-	    $cert_text =~ s/-----[^-]*-----//gm;
-	    $self->{KeyInfo} = "<dsig:KeyInfo><dsig:X509Data><dsig:X509Certificate>\n"._trim($cert_text)."\n</dsig:X509Certificate></dsig:X509Data></dsig:KeyInfo>";
+            $cert_text =~ s/-----[^-]*-----//gm;
+            $self->{KeyInfo} = "<dsig:KeyInfo><dsig:X509Data><dsig:X509Certificate>\n"._trim($cert_text)."\n</dsig:X509Certificate></dsig:X509Data></dsig:KeyInfo>";
         }
         else {
             confess "Could not load certificate from $file";
@@ -466,7 +466,7 @@ sub _load_cert_text {
     my $self = shift;
 
     eval {
-	require Crypt::OpenSSL::X509;
+        require Crypt::OpenSSL::X509;
     };
 
     confess "Crypt::OpenSSL::X509 needs to be installed so that we can handle X509 certs." if $@;
@@ -475,12 +475,12 @@ sub _load_cert_text {
     my $cert = Crypt::OpenSSL::X509->new_from_string($text);
     if ( $cert ) {
         $self->{ cert_obj } = $cert;
-	my $cert_text = $cert->as_string;
-	$cert_text =~ s/-----[^-]*-----//gm;
-	$self->{KeyInfo} = "<dsig:KeyInfo><dsig:X509Data><dsig:X509Certificate>\n"._trim($cert_text)."\n</dsig:X509Certificate></dsig:X509Data></dsig:KeyInfo>";
+        my $cert_text = $cert->as_string;
+        $cert_text =~ s/-----[^-]*-----//gm;
+        $self->{KeyInfo} = "<dsig:KeyInfo><dsig:X509Data><dsig:X509Certificate>\n"._trim($cert_text)."\n</dsig:X509Certificate></dsig:X509Data></dsig:KeyInfo>";
     }
     else {
-	    confess "Could not load certificate from given text.";
+            confess "Could not load certificate from given text.";
     }
 
     return;
@@ -507,11 +507,11 @@ sub _load_key {
             }
 
             return 1;
-	} elsif ( $text =~ m/BEGIN PRIVATE KEY/ ) {
-	    $self->_load_rsa_key( $text );
+        } elsif ( $text =~ m/BEGIN PRIVATE KEY/ ) {
+            $self->_load_rsa_key( $text );
         } elsif ($text =~ m/BEGIN CERTIFICATE/) {
-	    $self->_load_x509_key( $text );
-	}
+            $self->_load_x509_key( $text );
+        }
         else {
             confess "Could not detect type of key $file.";
         }
@@ -571,7 +571,7 @@ sub _canonicalize_xml {
     elsif ( $self->{ canonicalizer } eq 'XML::CanonicalizeXML' ) {
         require XML::CanonicalizeXML;
         my $xpath = '<XPath>(//. | //@* | //namespace::*)</XPath>';
-	return XML::CanonicalizeXML::canonicalize( $xml, $xpath, [], 1, $comments );
+        return XML::CanonicalizeXML::canonicalize( $xml, $xpath, [], 1, $comments );
     }
     else {
         confess "Unknown XML canonicalizer module.";
@@ -712,7 +712,7 @@ Now, let's insert a signature:
 
 =item L<Crypt::OpenSSL::RSA>
 
-=cut
+=back
 
 =head1 USAGE
 
@@ -728,7 +728,7 @@ This module supports the following signature methods:
 
 =item RSA encoded as x509
 
-=cut
+=back
 
 This module supports the following canonicalization methods and transforms:
 
@@ -740,11 +740,17 @@ This module supports the following canonicalization methods and transforms:
 
 =item Enveloped Signature
 
-=cut
+=back
 
 =head2 METHODS
 
 =over
+
+=item B<new(...)>
+
+Constructor; see OPTIONS below.
+
+=cut
 
 =item B<sign($xml)>
 
@@ -772,7 +778,7 @@ signer's certificate as embedded in the XML document for verification
 against a CA certificate. The certificate is returned as a
 Crypt::OpenSSL::X509 object.
 
-=cut
+=back
 
 =head2 OPTIONS
 
@@ -829,5 +835,7 @@ Author: Byrne Reese <byrne@majordojo.com>
 Thanks to Manni Heumann who wrote Google::SAML::Response from 
 which this module borrows heavily in order to create digital 
 signatures.
+
+Net::SAML2 embedded version amended by Chris Andrews <chris@nodnol.org>.
 
 =cut

--- a/lib/XML/Sig.pm
+++ b/lib/XML/Sig.pm
@@ -647,14 +647,7 @@ sub _canonicalize_xml {
     $comments = 0 unless $comments;
     $prefixlist = '' unless $prefixlist;
 
-    if ( $self->{canonicalizer} eq 'XML::Canonical' ) {
-        require XML::Canonical;
-
-        # TODO - pass prefixlist in here if X::C supports it
-        my $xmlcanon = XML::Canonical->new( comments => $comments );
-        return $xmlcanon->canonicalize_string( $xml );
-    }
-    elsif ( $self->{ canonicalizer } eq 'XML::CanonicalizeXML' ) {
+    if ( $self->{ canonicalizer } eq 'XML::CanonicalizeXML' ) {
         require XML::CanonicalizeXML;
         my $xpath = '<XPath>(//. | //@* | //namespace::*)</XPath>';
 
@@ -893,11 +886,11 @@ should match the private key used for the signature.
 
 The XML canonicalization library to use. Options currently are:
 
+XML::Canonical was removed as an option due to its age
+
 =over
 
 =item XML::CanonicalizerXML (default)
-
-=item XML::Canonicalizer
 
 =back
 

--- a/lib/XML/Sig.pm
+++ b/lib/XML/Sig.pm
@@ -7,7 +7,7 @@ use warnings;
 use vars qw($VERSION @EXPORT_OK %EXPORT_TAGS $DEBUG);
 
 $DEBUG = 0;
-$VERSION = '0.23_02';
+$VERSION = '0.24';
 
 use base qw(Class::Accessor);
 XML::Sig->mk_accessors(qw(canonicalizer key));

--- a/lib/XML/Sig.pm
+++ b/lib/XML/Sig.pm
@@ -7,7 +7,7 @@ use warnings;
 use vars qw($VERSION @EXPORT_OK %EXPORT_TAGS $DEBUG);
 
 $DEBUG = 0;
-$VERSION = '0.25';
+$VERSION = '0.26';
 
 use base qw(Class::Accessor);
 XML::Sig->mk_accessors(qw(canonicalizer key));

--- a/lib/XML/Sig.pm
+++ b/lib/XML/Sig.pm
@@ -118,69 +118,77 @@ sub verify {
     $self->{ parser }->set_namespace('dsig', 'http://www.w3.org/2000/09/xmldsig#');
     $self->{ parser }->set_namespace('ec', 'http://www.w3.org/2001/10/xml-exc-c14n#');
 
-    my $signature = _trim($self->{parser}->findvalue('/descendant::dsig:Signature[1]/dsig:SignatureValue'));
-    my $signed_info_node = $self->_get_node('/descendant::dsig:Signature[1]/dsig:SignedInfo');
+    my $signature_nodeset = $self->{parser}->findnodes('//dsig:Signature');
 
-    my $signature_node = $self->_get_node('/descendant::dsig:Signature[1]');
-    my $ns;
-    if (defined $signature_node && ref $signature_node) {
+    while (my $signature_node = $signature_nodeset->shift()) {
+
+        my $value = $self->{parser}->findvalue('dsig:SignatureValue', $signature_node);
+
+        my $signature = _trim($self->{parser}->findvalue('dsig:SignatureValue', $signature_node));
+        my $signed_info_node = $self->_get_node('dsig:SignedInfo', $signature_node);
+
+        my $ns;
+        if (defined $signature_node && ref $signature_node) {
             $ns = $signature_node->getNamespaces->[0];
             $self->{dsig_prefix} = ($ns->getPrefix eq '#default') ? '' : $ns->getPrefix;
-    }
-    else {
+        }
+        else {
             die "no Signature node?";
-    }
+        }
     
-    if (scalar @{ $signed_info_node->getNamespaces } == 0) {
-        $signed_info_node->appendNamespace($ns);
-    }
+        if (scalar @{ $signed_info_node->getNamespaces } == 0) {
+            $signed_info_node->appendNamespace($ns);
+        }
     
-    my $signed_info = XML::XPath::XMLParser::as_string($signed_info_node);
-    my $signed_info_canon = $self->_canonicalize_xml( $signed_info );
+        my $signed_info = XML::XPath::XMLParser::as_string($signed_info_node);
+        my $signed_info_canon = $self->_canonicalize_xml( $signed_info );
+        my $digest_method = $self->{parser}->findvalue('dsig:SignedInfo/dsig:Reference/dsig:DigestMethod/@Algorithm', $signature_node);
+        $digest_method =~ s/^.*[#]//;
+
+        if(Digest::SHA->can($digest_method)) {
+            my $rsa_hash = "use_$digest_method" . "_hash";
+            $self->{rsa_hash} =  "use_$digest_method" . "_hash";
+            $self->{digest_method} = \&$digest_method;
+        }
+        else {
+            die("Can't handle $digest_method");
+        }
 
 
-    my $digest_method = $self->{parser}->findvalue('dsig:SignedInfo/dsig:Reference/dsig:DigestMethod/@Algorithm', $signature_node);
-    $digest_method =~ s/^.*[#]//;
-
-    if(Digest::SHA->can($digest_method)) {
-        my $rsa_hash = "use_$digest_method" . "_hash";
-        $self->{rsa_hash} =  "use_$digest_method" . "_hash";
-        $self->{digest_method} = \&$digest_method;
-    }
-    else {
-        die("Can't handle $digest_method");
-    }
-
-
-    if (defined $self->{cert_obj}) {
+        if (defined $self->{cert_obj}) {
             # use the provided cert to verify
-            return 0 unless $self->_verify_x509_cert($self->{cert_obj},$signed_info_canon,$signature);
-    }
-    else {
+            unless ($self->_verify_x509_cert($self->{cert_obj},$signed_info_canon,$signature)) {
+                print STDERR "not verified by x509\n";
+                return 0;
+            }
+        }
+        else {
             # extract the certficate or key from the document
             my $keyinfo_node;
-            if ($keyinfo_node = $self->{parser}->find('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:X509Data')) {
+            if ($keyinfo_node = $self->{parser}->find('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:X509Data', $signature_node)) {
                     return 0 unless $self->_verify_x509($keyinfo_node,$signed_info_canon, $signature);
             } 
-            elsif ($keyinfo_node = $self->{parser}->find('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:KeyValue/dsig:RSAKeyValue')) {
+            elsif ($keyinfo_node = $self->{parser}->find('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:KeyValue/dsig:RSAKeyValue', $signature_node)) {
                     return 0 unless $self->_verify_rsa($keyinfo_node,$signed_info_canon,$signature);
             }
-            elsif ($keyinfo_node = $self->{parser}->find('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue')) {
+            elsif ($keyinfo_node = $self->{parser}->find('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue', $signature_node)) {
                     return 0 unless $self->_verify_dsa($keyinfo_node,$signed_info_canon,$signature);
             }
             else {
-                    die "Unrecognized key type or no KeyInfo in document";
+                die "Unrecognized key type or no KeyInfo in document";
             }
+        }
+
+        my $digest_method = $self->{parser}->findvalue('dsig:Reference/dsig:DigestMethod/@Algorithm', $signed_info_node);
+        my $refdigest     = _trim($self->{parser}->findvalue('dsig:Reference/dsig:DigestValue', $signed_info_node));
+    
+        my $signed_xml    = $self->_get_signed_xml( $signature_node );
+        my $canonical     = $self->_transform( $signed_xml, $signature_node );
+        my $digest    = $self->{digest_method}->($canonical);
+        return 0 unless ($refdigest eq _trim(encode_base64($digest));
     }
-
-    my $digest = _trim($self->{parser}->findvalue('dsig:SignedInfo/dsig:Reference/dsig:DigestValue', $signature_node));
-
-    my $signed_xml    = $self->_get_signed_xml($signature_node);
-    my $canonical     = $self->_transform($signed_xml, $signature_node);
-    my $digest_bin    = $self->{digest_method}->($canonical);
-
-    return 1 if ($digest eq _trim(encode_base64($digest_bin)));
-    return 0;
+    
+    return 1;
 }
 
 sub signer_cert {
@@ -199,7 +207,7 @@ sub _get_xml_to_sign {
 
 sub _get_signed_xml {
     my $self = shift;
-    my $context = shift;
+    my ($context) = @_;
 
     my $id = $self->{parser}->findvalue('dsig:SignedInfo/dsig:Reference/@URI', $context);
     $id =~ s/^#//;
@@ -250,9 +258,9 @@ sub _verify_rsa {
     my ($context,$canonical,$sig) = @_;
 
     # Generate Public Key from XML
-    my $mod = _trim($self->{parser}->findvalue('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:KeyValue/dsig:RSAKeyValue/dsig:Modulus'));
+    my $mod = _trim($self->{parser}->findvalue('dsig:Modulus', $context));
     my $modBin = decode_base64( $mod );
-    my $exp = _trim($self->{parser}->findvalue('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:KeyValue/dsig:RSAKeyValue/dsig:Exponent'));
+    my $exp = _trim($self->{parser}->findvalue('dsig:Exponent', $context));
     my $expBin = decode_base64( $exp );
     my $n = Crypt::OpenSSL::Bignum->new_from_bin($modBin);
     my $e = Crypt::OpenSSL::Bignum->new_from_bin($expBin);
@@ -297,12 +305,13 @@ sub _verify_x509 {
     confess "Crypt::OpenSSL::X509 needs to be installed so that we can handle X509 certificates" if $@;
 
     # Generate Public Key from XML
-    my $certificate = _trim($self->{parser}->findvalue('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:X509Data/dsig:X509Certificate'));
+    my $certificate = _trim($self->{parser}->findvalue('dsig:X509Certificate', $context));
 
     # This is added because the X509 parser requires it for self-identification
     $certificate = $self->_clean_x509($certificate);
 
     my $cert = Crypt::OpenSSL::X509->new_from_string($certificate);
+
     return $self->_verify_x509_cert($cert, $canonical, $sig);
 }
 
@@ -338,10 +347,10 @@ sub _verify_dsa {
     };
 
     # Generate Public Key from XML
-    my $p = decode_base64(_trim($self->{parser}->findvalue('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue/dsig:P')));
-    my $q = decode_base64(_trim($self->{parser}->findvalue('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue/dsig:Q')));
-    my $g = decode_base64(_trim($self->{parser}->findvalue('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue/dsig:G')));
-    my $y = decode_base64(_trim($self->{parser}->findvalue('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue/dsig:Y')));
+    my $p = decode_base64(_trim($self->{parser}->findvalue('dsig:P', $context)));
+    my $q = decode_base64(_trim($self->{parser}->findvalue('dsig:Q', $context)));
+    my $g = decode_base64(_trim($self->{parser}->findvalue('dsig:G', $context)));
+    my $y = decode_base64(_trim($self->{parser}->findvalue('dsig:Y', $context)));
     my $dsa_pub = Crypt::OpenSSL::DSA->new();
     $dsa_pub->set_p($p);
     $dsa_pub->set_q($q);
@@ -357,8 +366,13 @@ sub _verify_dsa {
 
 sub _get_node {
     my $self = shift;
-    my ($xpath) = @_;
-    my $nodeset = $self->{parser}->find($xpath);
+    my ($xpath, $context) = @_;
+    my $nodeset;
+    if ($context) {
+         $nodeset = $self->{parser}->find($xpath, $context);
+    } else {
+         $nodeset = $self->{parser}->find($xpath);
+    }
     foreach my $node ($nodeset->get_nodelist) {
         return $node; 
     }
@@ -376,7 +390,12 @@ sub _transform_env_sig {
     if (defined $self->{dsig_prefix} && length $self->{dsig_prefix}) {
         $prefix = $self->{dsig_prefix} . ':';
     }
+
+    # This removes the first Signature tag from the XML - even if there is another XML tree with another Signature inside and that comes first.
+    # TODO: Remove the outermost Signature only.
+
     $str =~ s/(<${prefix}Signature(.*?)>(.*?)\<\/${prefix}Signature>)//is;
+
     return $str;
 }
 
@@ -596,7 +615,7 @@ sub _signedinfo_xml {
     my $self = shift;
     my ($digest_xml) = @_;
 
-    return qq{<dsig:SignedInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#">
+    return qq{<dsig:SignedInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#">
                 <dsig:CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments" />
                 <dsig:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#$self->{key_type}-sha1" />
                 $digest_xml
@@ -626,9 +645,7 @@ sub _canonicalize_xml {
     if ( $self->{canonicalizer} eq 'XML::Canonical' ) {
         require XML::Canonical;
 
-        # XML::Canonical doesn't support a prefix list, so
-        # InclusiveNamespaces will have no effect
-
+        # TODO - pass prefixlist in here if X::C supports it
         my $xmlcanon = XML::Canonical->new( comments => $comments );
         return $xmlcanon->canonicalize_string( $xml );
     }

--- a/lib/XML/Sig.pm
+++ b/lib/XML/Sig.pm
@@ -116,56 +116,78 @@ sub verify {
     $self->{ parser }->set_namespace('dsig', 'http://www.w3.org/2000/09/xmldsig#');
     $self->{ parser }->set_namespace('ec', 'http://www.w3.org/2001/10/xml-exc-c14n#');
 
-    my $signature = _trim($self->{parser}->findvalue('//dsig:Signature/dsig:SignatureValue'));
-    my $signed_info_node = $self->_get_node('//dsig:Signature/dsig:SignedInfo');
+    my $signature_nodeset = $self->{parser}->findnodes('//dsig:Signature');
 
-    my $signature_node = $self->_get_node('//dsig:Signature');
-    my $ns;
-    if (defined $signature_node && ref $signature_node) {
+    while (my $signature_node = $signature_nodeset->shift()) {
+
+        my $value = $self->{parser}->findvalue('dsig:SignatureValue', $signature_node);
+
+        my $signature = _trim($self->{parser}->findvalue('dsig:SignatureValue', $signature_node));
+        my $signed_info_node = $self->_get_node('dsig:SignedInfo', $signature_node);
+
+        my $ns;
+        if (defined $signature_node && ref $signature_node) {
             $ns = $signature_node->getNamespaces->[0];
             $self->{dsig_prefix} = ($ns->getPrefix eq '#default') ? '' : $ns->getPrefix;
-    }
-    else {
+        }
+        else {
             die "no Signature node?";
-    }
+        }
     
-    if (scalar @{ $signed_info_node->getNamespaces } == 0) {
-        $signed_info_node->appendNamespace($ns);
-    }
+        if (scalar @{ $signed_info_node->getNamespaces } == 0) {
+            $signed_info_node->appendNamespace($ns);
+        }
     
-    my $signed_info = XML::XPath::XMLParser::as_string($signed_info_node);
-    my $signed_info_canon = $self->_canonicalize_xml( $signed_info );
+        my $signed_info = XML::XPath::XMLParser::as_string($signed_info_node);
+        my $signed_info_canon = $self->_canonicalize_xml( $signed_info );
 
-    if (defined $self->{cert_obj}) {
+        if (defined $self->{cert_obj}) {
             # use the provided cert to verify
-            return 0 unless $self->_verify_x509_cert($self->{cert_obj},$signed_info_canon,$signature);
-    }
-    else {
-            # extract the certficate or key from the document
-            my $keyinfo_node;
-            if ($keyinfo_node = $self->{parser}->find('//dsig:Signature/dsig:KeyInfo/dsig:X509Data')) {
-                    return 0 unless $self->_verify_x509($keyinfo_node,$signed_info_canon,$signature);
-            } 
-            elsif ($keyinfo_node = $self->{parser}->find('//dsig:Signature/dsig:KeyInfo/dsig:KeyValue/dsig:RSAKeyValue')) {
-                    return 0 unless $self->_verify_rsa($keyinfo_node,$signed_info_canon,$signature);
+            unless ($self->_verify_x509_cert($self->{cert_obj},$signed_info_canon,$signature)) {
+                print STDERR "not verified by x509\n";
+                return 0;
             }
-            elsif ($keyinfo_node = $self->{parser}->find('//dsig:Signature/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue')) {
-                    return 0 unless $self->_verify_dsa($keyinfo_node,$signed_info_canon,$signature);
+        }
+        else {
+            # extract the certficate or key from the document
+            my $keyinfo_nodeset;
+            if ($keyinfo_nodeset = $self->{parser}->findnodes('dsig:KeyInfo/dsig:X509Data', $signature_node)) {
+                my $keyinfo_node = $keyinfo_nodeset->shift();
+                unless ($self->_verify_x509($keyinfo_node,$signed_info_canon,$signature)) {
+                    print STDERR "not verified by x509\n";
+                    return 0;
+                }
+            }
+            elsif ($keyinfo_nodeset = $self->{parser}->find('dsig:KeyInfo/dsig:KeyValue/dsig:RSAKeyValue', $signature_node)) {
+                my $keyinfo_node = $keyinfo_nodeset->shift();
+                unless ($self->_verify_rsa($keyinfo_node,$signed_info_canon,$signature)) {
+                    print STDERR "not verified by rsa\n";
+                    return 0;
+                }
+            }
+            elsif ($keyinfo_nodeset = $self->{parser}->find('dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue', $signature_node)) {
+                my $keyinfo_node = $keyinfo_nodeset->shift();
+                unless ($self->_verify_dsa($keyinfo_node,$signed_info_canon,$signature)) {
+                    print STDERR "not verified by dsa\n";
+                    return 0;
+                }
             }
             else {
-                    die "Unrecognized key type or no KeyInfo in document";
+                die "Unrecognized key type or no KeyInfo in document";
             }
+        }
+
+        my $digest_method = $self->{parser}->findvalue('dsig:Reference/dsig:DigestMethod/@Algorithm', $signed_info_node);
+        my $refdigest     = _trim($self->{parser}->findvalue('dsig:Reference/dsig:DigestValue', $signed_info_node));
+    
+        my $signed_xml    = $self->_get_signed_xml( $signature_node );
+        my $canonical     = $self->_transform( $signed_xml, $signature_node );
+        my $digest        = encode_base64(_trim(sha1( $canonical )), '');
+
+        return 0 unless ($digest eq $refdigest);
     }
-
-    my $digest_method = $self->{parser}->findvalue('dsig:SignedInfo/dsig:Reference/dsig:DigestMethod/@Algorithm', $signature_node);
-    my $digest = _trim($self->{parser}->findvalue('dsig:SignedInfo/dsig:Reference/dsig:DigestValue', $signature_node));
-
-    my $signed_xml    = $self->_get_signed_xml($signature_node);
-    my $canonical     = $self->_transform($signed_xml, $signature_node);
-    my $digest_bin    = sha1($canonical);
-
-    return 1 if ($digest eq _trim(encode_base64($digest_bin)));
-    return 0;
+    
+    return 1;
 }
 
 sub signer_cert {
@@ -184,8 +206,7 @@ sub _get_xml_to_sign {
 
 sub _get_signed_xml {
     my $self = shift;
-    my $context = shift;
-
+    my ($context) = @_;
     my $id = $self->{parser}->findvalue('dsig:SignedInfo/dsig:Reference/@URI', $context);
     $id =~ s/^#//;
     $self->{'sign_id'} = $id;
@@ -235,9 +256,9 @@ sub _verify_rsa {
     my ($context,$canonical,$sig) = @_;
 
     # Generate Public Key from XML
-    my $mod = _trim($self->{parser}->findvalue('//dsig:Signature/dsig:KeyInfo/dsig:KeyValue/dsig:RSAKeyValue/dsig:Modulus'));
+    my $mod = _trim($self->{parser}->findvalue('dsig:Modulus', $context));
     my $modBin = decode_base64( $mod );
-    my $exp = _trim($self->{parser}->findvalue('//dsig:Signature/dsig:KeyInfo/dsig:KeyValue/dsig:RSAKeyValue/dsig:Exponent'));
+    my $exp = _trim($self->{parser}->findvalue('dsig:Exponent', $context));
     my $expBin = decode_base64( $exp );
     my $n = Crypt::OpenSSL::Bignum->new_from_bin($modBin);
     my $e = Crypt::OpenSSL::Bignum->new_from_bin($expBin);
@@ -279,12 +300,13 @@ sub _verify_x509 {
     confess "Crypt::OpenSSL::X509 needs to be installed so that we can handle X509 certificates" if $@;
 
     # Generate Public Key from XML
-    my $certificate = _trim($self->{parser}->findvalue('//dsig:Signature/dsig:KeyInfo/dsig:X509Data/dsig:X509Certificate'));
+    my $certificate = _trim($self->{parser}->findvalue('dsig:X509Certificate', $context));
 
     # This is added because the X509 parser requires it for self-identification
     $certificate = $self->_clean_x509($certificate);
 
     my $cert = Crypt::OpenSSL::X509->new_from_string($certificate);
+
     return $self->_verify_x509_cert($cert, $canonical, $sig);
 }
 
@@ -319,10 +341,10 @@ sub _verify_dsa {
     };
 
     # Generate Public Key from XML
-    my $p = decode_base64(_trim($self->{parser}->findvalue('//dsig:Signature/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue/dsig:P')));
-    my $q = decode_base64(_trim($self->{parser}->findvalue('//dsig:Signature/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue/dsig:Q')));
-    my $g = decode_base64(_trim($self->{parser}->findvalue('//dsig:Signature/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue/dsig:G')));
-    my $y = decode_base64(_trim($self->{parser}->findvalue('//dsig:Signature/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue/dsig:Y')));
+    my $p = decode_base64(_trim($self->{parser}->findvalue('dsig:P', $context)));
+    my $q = decode_base64(_trim($self->{parser}->findvalue('dsig:Q', $context)));
+    my $g = decode_base64(_trim($self->{parser}->findvalue('dsig:G', $context)));
+    my $y = decode_base64(_trim($self->{parser}->findvalue('dsig:Y', $context)));
     my $dsa_pub = Crypt::OpenSSL::DSA->new();
     $dsa_pub->set_p($p);
     $dsa_pub->set_q($q);
@@ -338,8 +360,13 @@ sub _verify_dsa {
 
 sub _get_node {
     my $self = shift;
-    my ($xpath) = @_;
-    my $nodeset = $self->{parser}->find($xpath);
+    my ($xpath, $context) = @_;
+    my $nodeset;
+    if ($context) {
+         $nodeset = $self->{parser}->find($xpath, $context);
+    } else {
+         $nodeset = $self->{parser}->find($xpath);
+    }
     foreach my $node ($nodeset->get_nodelist) {
         return $node; 
     }
@@ -357,7 +384,11 @@ sub _transform_env_sig {
     if (defined $self->{dsig_prefix} && length $self->{dsig_prefix}) {
         $prefix = $self->{dsig_prefix} . ':';
     }
+    # This removes the first Signature tag from the XML - even if there is another XML tree with another Signature inside and that comes first.
+    # TODO: Remove the outermost Signature only.
+
     $str =~ s/(<${prefix}Signature(.*?)>(.*?)\<\/${prefix}Signature>)//is;
+
     return $str;
 }
 
@@ -577,7 +608,7 @@ sub _signedinfo_xml {
     my $self = shift;
     my ($digest_xml) = @_;
 
-    return qq{<dsig:SignedInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#">
+    return qq{<dsig:SignedInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#">
                 <dsig:CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments" />
                 <dsig:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#$self->{key_type}-sha1" />
                 $digest_xml
@@ -607,9 +638,7 @@ sub _canonicalize_xml {
     if ( $self->{canonicalizer} eq 'XML::Canonical' ) {
         require XML::Canonical;
 
-        # XML::Canonical doesn't support a prefix list, so
-        # InclusiveNamespaces will have no effect
-
+        # TODO - pass prefixlist in here if X::C supports it
         my $xmlcanon = XML::Canonical->new( comments => $comments );
         return $xmlcanon->canonicalize_string( $xml );
     }

--- a/lib/XML/Sig.pm
+++ b/lib/XML/Sig.pm
@@ -177,7 +177,7 @@ sub verify {
                     if ( ! $self->$verify_method($keyinfo_nodeset->get_node(0), $signed_info_canon, $signature) ) {
                         print STDERR "Failed to verify using $verify_method\n";
                         return 0;
-                    } 
+                    }
                     last;
                 }
             }
@@ -192,7 +192,7 @@ sub verify {
         my $digest    = $self->{digest_method}->($canonical);
         return 0 unless ($refdigest eq _trim(encode_base64($digest, '')));
     }
-    
+
     return 1;
 }
 

--- a/lib/XML/Sig.pm
+++ b/lib/XML/Sig.pm
@@ -171,7 +171,11 @@ sub verify {
             );
             my $keyinfo_nodeset;
             foreach my $key_info_sig_type ( qw/X509Data RSAKeyValue DSAKeyValue/ ) {
-                $keyinfo_nodeset = $self->{parser}->find("/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:$key_info_sig_type", $signature_node);
+                if ( $key_info_sig_type eq 'X509Data' ) {
+                    $keyinfo_nodeset = $self->{parser}->find("/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:$key_info_sig_type", $signature_node);
+                } else {
+                    $keyinfo_nodeset = $self->{parser}->find("/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:KeyValue/dsig:$key_info_sig_type", $signature_node);
+                }
                 if ( $keyinfo_nodeset->size ) {
                     my $verify_method = $verify_dispatch{$key_info_sig_type};
                     if ( ! $self->$verify_method($keyinfo_nodeset->get_node(0), $signed_info_canon, $signature) ) {

--- a/lib/XML/Sig.pm
+++ b/lib/XML/Sig.pm
@@ -7,7 +7,7 @@ use warnings;
 use vars qw($VERSION @EXPORT_OK %EXPORT_TAGS $DEBUG);
 
 $DEBUG = 0;
-$VERSION = '0.24';
+$VERSION = '0.25';
 
 use base qw(Class::Accessor);
 XML::Sig->mk_accessors(qw(canonicalizer key));

--- a/lib/XML/Sig.pm
+++ b/lib/XML/Sig.pm
@@ -1,5 +1,8 @@
 package XML::Sig;
 
+use strict;
+use warnings;
+
 # use 'our' on v5.6.0
 use vars qw($VERSION @EXPORT_OK %EXPORT_TAGS $DEBUG);
 
@@ -15,9 +18,8 @@ use base qw/Exporter/;
 # Export list - to allow fine tuning of export table
 @EXPORT_OK = qw( sign verify );
 
-use strict;
 
-use Digest::SHA qw(sha1 sha1_base64);
+use Digest::SHA qw(sha1 sha224 sha256 sha384 sha512);
 use XML::XPath;
 use MIME::Base64;
 use Carp;
@@ -116,78 +118,69 @@ sub verify {
     $self->{ parser }->set_namespace('dsig', 'http://www.w3.org/2000/09/xmldsig#');
     $self->{ parser }->set_namespace('ec', 'http://www.w3.org/2001/10/xml-exc-c14n#');
 
-    my $signature_nodeset = $self->{parser}->findnodes('//dsig:Signature');
+    my $signature = _trim($self->{parser}->findvalue('/descendant::dsig:Signature[1]/dsig:SignatureValue'));
+    my $signed_info_node = $self->_get_node('/descendant::dsig:Signature[1]/dsig:SignedInfo');
 
-    while (my $signature_node = $signature_nodeset->shift()) {
-
-        my $value = $self->{parser}->findvalue('dsig:SignatureValue', $signature_node);
-
-        my $signature = _trim($self->{parser}->findvalue('dsig:SignatureValue', $signature_node));
-        my $signed_info_node = $self->_get_node('dsig:SignedInfo', $signature_node);
-
-        my $ns;
-        if (defined $signature_node && ref $signature_node) {
+    my $signature_node = $self->_get_node('/descendant::dsig:Signature[1]');
+    my $ns;
+    if (defined $signature_node && ref $signature_node) {
             $ns = $signature_node->getNamespaces->[0];
             $self->{dsig_prefix} = ($ns->getPrefix eq '#default') ? '' : $ns->getPrefix;
-        }
-        else {
+    }
+    else {
             die "no Signature node?";
-        }
-    
-        if (scalar @{ $signed_info_node->getNamespaces } == 0) {
-            $signed_info_node->appendNamespace($ns);
-        }
-    
-        my $signed_info = XML::XPath::XMLParser::as_string($signed_info_node);
-        my $signed_info_canon = $self->_canonicalize_xml( $signed_info );
-
-        if (defined $self->{cert_obj}) {
-            # use the provided cert to verify
-            unless ($self->_verify_x509_cert($self->{cert_obj},$signed_info_canon,$signature)) {
-                print STDERR "not verified by x509\n";
-                return 0;
-            }
-        }
-        else {
-            # extract the certficate or key from the document
-            my $keyinfo_nodeset;
-            if ($keyinfo_nodeset = $self->{parser}->findnodes('dsig:KeyInfo/dsig:X509Data', $signature_node)) {
-                my $keyinfo_node = $keyinfo_nodeset->shift();
-                unless ($self->_verify_x509($keyinfo_node,$signed_info_canon,$signature)) {
-                    print STDERR "not verified by x509\n";
-                    return 0;
-                }
-            }
-            elsif ($keyinfo_nodeset = $self->{parser}->find('dsig:KeyInfo/dsig:KeyValue/dsig:RSAKeyValue', $signature_node)) {
-                my $keyinfo_node = $keyinfo_nodeset->shift();
-                unless ($self->_verify_rsa($keyinfo_node,$signed_info_canon,$signature)) {
-                    print STDERR "not verified by rsa\n";
-                    return 0;
-                }
-            }
-            elsif ($keyinfo_nodeset = $self->{parser}->find('dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue', $signature_node)) {
-                my $keyinfo_node = $keyinfo_nodeset->shift();
-                unless ($self->_verify_dsa($keyinfo_node,$signed_info_canon,$signature)) {
-                    print STDERR "not verified by dsa\n";
-                    return 0;
-                }
-            }
-            else {
-                die "Unrecognized key type or no KeyInfo in document";
-            }
-        }
-
-        my $digest_method = $self->{parser}->findvalue('dsig:Reference/dsig:DigestMethod/@Algorithm', $signed_info_node);
-        my $refdigest     = _trim($self->{parser}->findvalue('dsig:Reference/dsig:DigestValue', $signed_info_node));
-    
-        my $signed_xml    = $self->_get_signed_xml( $signature_node );
-        my $canonical     = $self->_transform( $signed_xml, $signature_node );
-        my $digest        = encode_base64(_trim(sha1( $canonical )), '');
-
-        return 0 unless ($digest eq $refdigest);
     }
     
-    return 1;
+    if (scalar @{ $signed_info_node->getNamespaces } == 0) {
+        $signed_info_node->appendNamespace($ns);
+    }
+    
+    my $signed_info = XML::XPath::XMLParser::as_string($signed_info_node);
+    my $signed_info_canon = $self->_canonicalize_xml( $signed_info );
+
+
+    my $digest_method = $self->{parser}->findvalue('dsig:SignedInfo/dsig:Reference/dsig:DigestMethod/@Algorithm', $signature_node);
+    $digest_method =~ s/^.*[#]//;
+
+    if(Digest::SHA->can($digest_method)) {
+        my $rsa_hash = "use_$digest_method" . "_hash";
+        $self->{rsa_hash} =  "use_$digest_method" . "_hash";
+        $self->{digest_method} = \&$digest_method;
+    }
+    else {
+        die("Can't handle $digest_method");
+    }
+
+
+    if (defined $self->{cert_obj}) {
+            # use the provided cert to verify
+            return 0 unless $self->_verify_x509_cert($self->{cert_obj},$signed_info_canon,$signature);
+    }
+    else {
+            # extract the certficate or key from the document
+            my $keyinfo_node;
+            if ($keyinfo_node = $self->{parser}->find('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:X509Data')) {
+                    return 0 unless $self->_verify_x509($keyinfo_node,$signed_info_canon, $signature);
+            } 
+            elsif ($keyinfo_node = $self->{parser}->find('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:KeyValue/dsig:RSAKeyValue')) {
+                    return 0 unless $self->_verify_rsa($keyinfo_node,$signed_info_canon,$signature);
+            }
+            elsif ($keyinfo_node = $self->{parser}->find('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue')) {
+                    return 0 unless $self->_verify_dsa($keyinfo_node,$signed_info_canon,$signature);
+            }
+            else {
+                    die "Unrecognized key type or no KeyInfo in document";
+            }
+    }
+
+    my $digest = _trim($self->{parser}->findvalue('dsig:SignedInfo/dsig:Reference/dsig:DigestValue', $signature_node));
+
+    my $signed_xml    = $self->_get_signed_xml($signature_node);
+    my $canonical     = $self->_transform($signed_xml, $signature_node);
+    my $digest_bin    = $self->{digest_method}->($canonical);
+
+    return 1 if ($digest eq _trim(encode_base64($digest_bin)));
+    return 0;
 }
 
 sub signer_cert {
@@ -206,7 +199,8 @@ sub _get_xml_to_sign {
 
 sub _get_signed_xml {
     my $self = shift;
-    my ($context) = @_;
+    my $context = shift;
+
     my $id = $self->{parser}->findvalue('dsig:SignedInfo/dsig:Reference/@URI', $context);
     $id =~ s/^#//;
     $self->{'sign_id'} = $id;
@@ -256,9 +250,9 @@ sub _verify_rsa {
     my ($context,$canonical,$sig) = @_;
 
     # Generate Public Key from XML
-    my $mod = _trim($self->{parser}->findvalue('dsig:Modulus', $context));
+    my $mod = _trim($self->{parser}->findvalue('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:KeyValue/dsig:RSAKeyValue/dsig:Modulus'));
     my $modBin = decode_base64( $mod );
-    my $exp = _trim($self->{parser}->findvalue('dsig:Exponent', $context));
+    my $exp = _trim($self->{parser}->findvalue('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:KeyValue/dsig:RSAKeyValue/dsig:Exponent'));
     my $expBin = decode_base64( $exp );
     my $n = Crypt::OpenSSL::Bignum->new_from_bin($modBin);
     my $e = Crypt::OpenSSL::Bignum->new_from_bin($expBin);
@@ -273,6 +267,9 @@ sub _verify_rsa {
 sub _clean_x509 {
     my $self = shift;
     my ($cert) = @_;
+
+    $cert = $cert->value() if(ref $cert);
+    chomp($cert);
 
     # rewrap the base64 data from the certificate; it may not be
     # wrapped at 64 characters as PEM requires
@@ -300,13 +297,12 @@ sub _verify_x509 {
     confess "Crypt::OpenSSL::X509 needs to be installed so that we can handle X509 certificates" if $@;
 
     # Generate Public Key from XML
-    my $certificate = _trim($self->{parser}->findvalue('dsig:X509Certificate', $context));
+    my $certificate = _trim($self->{parser}->findvalue('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:X509Data/dsig:X509Certificate'));
 
     # This is added because the X509 parser requires it for self-identification
     $certificate = $self->_clean_x509($certificate);
 
     my $cert = Crypt::OpenSSL::X509->new_from_string($certificate);
-
     return $self->_verify_x509_cert($cert, $canonical, $sig);
 }
 
@@ -322,6 +318,8 @@ sub _verify_x509_cert {
     # Decode signature and verify
     my $bin_signature = decode_base64($sig);
 
+    my $rsa_hash = $self->{rsa_hash};
+    $rsa_pub->$rsa_hash();
     # If successful verify, store the signer's cert for validation
     if ($rsa_pub->verify( $canonical,  $bin_signature )) {
         $self->{signer_cert} = $cert;
@@ -330,7 +328,6 @@ sub _verify_x509_cert {
 
     return 0;
 }
-
 
 sub _verify_dsa {
     my $self = shift;
@@ -341,10 +338,10 @@ sub _verify_dsa {
     };
 
     # Generate Public Key from XML
-    my $p = decode_base64(_trim($self->{parser}->findvalue('dsig:P', $context)));
-    my $q = decode_base64(_trim($self->{parser}->findvalue('dsig:Q', $context)));
-    my $g = decode_base64(_trim($self->{parser}->findvalue('dsig:G', $context)));
-    my $y = decode_base64(_trim($self->{parser}->findvalue('dsig:Y', $context)));
+    my $p = decode_base64(_trim($self->{parser}->findvalue('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue/dsig:P')));
+    my $q = decode_base64(_trim($self->{parser}->findvalue('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue/dsig:Q')));
+    my $g = decode_base64(_trim($self->{parser}->findvalue('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue/dsig:G')));
+    my $y = decode_base64(_trim($self->{parser}->findvalue('/descendant::dsig:Signature[1]/dsig:KeyInfo/dsig:KeyValue/dsig:DSAKeyValue/dsig:Y')));
     my $dsa_pub = Crypt::OpenSSL::DSA->new();
     $dsa_pub->set_p($p);
     $dsa_pub->set_q($q);
@@ -354,19 +351,14 @@ sub _verify_dsa {
     # Decode signature and verify
     my $bin_signature = decode_base64($sig);
     # DSA signatures are limited to a message body of 20 characters, so a sha1 digest is taken
-    return 1 if ($dsa_pub->verify( sha1($canonical),  $bin_signature ));
+    return 1 if ($dsa_pub->verify( $self->{digest_method}->($canonical),  $bin_signature ));
     return 0;
 }
 
 sub _get_node {
     my $self = shift;
-    my ($xpath, $context) = @_;
-    my $nodeset;
-    if ($context) {
-         $nodeset = $self->{parser}->find($xpath, $context);
-    } else {
-         $nodeset = $self->{parser}->find($xpath);
-    }
+    my ($xpath) = @_;
+    my $nodeset = $self->{parser}->find($xpath);
     foreach my $node ($nodeset->get_nodelist) {
         return $node; 
     }
@@ -384,11 +376,7 @@ sub _transform_env_sig {
     if (defined $self->{dsig_prefix} && length $self->{dsig_prefix}) {
         $prefix = $self->{dsig_prefix} . ':';
     }
-    # This removes the first Signature tag from the XML - even if there is another XML tree with another Signature inside and that comes first.
-    # TODO: Remove the outermost Signature only.
-
     $str =~ s/(<${prefix}Signature(.*?)>(.*?)\<\/${prefix}Signature>)//is;
-
     return $str;
 }
 
@@ -608,7 +596,7 @@ sub _signedinfo_xml {
     my $self = shift;
     my ($digest_xml) = @_;
 
-    return qq{<dsig:SignedInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#">
+    return qq{<dsig:SignedInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#">
                 <dsig:CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments" />
                 <dsig:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#$self->{key_type}-sha1" />
                 $digest_xml
@@ -638,7 +626,9 @@ sub _canonicalize_xml {
     if ( $self->{canonicalizer} eq 'XML::Canonical' ) {
         require XML::Canonical;
 
-        # TODO - pass prefixlist in here if X::C supports it
+        # XML::Canonical doesn't support a prefix list, so
+        # InclusiveNamespaces will have no effect
+
         my $xmlcanon = XML::Canonical->new( comments => $comments );
         return $xmlcanon->canonicalize_string( $xml );
     }


### PR DESCRIPTION
This PR serves to bring XML::Sig in line with the changes from Net::SAML2 that occurred after development stopped on XML::Sig. 

Each of the commits should result in only namespace differences between the lib/XML/Sig.pm and lib/Net/SAML2/XML/Sig.pm at that particular patch.  In a couple of cases I had to patch the commit for differences that would be related to the merge history.

At this point one should be able to drop Net::SAML2::XML::Sig and use XML::Sig in Net::SAML2

