### PR TITLE
Sign SAML metadata correctly

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -38,11 +38,12 @@ my %WriteMakefileArgs = (
   },
   "TEST_REQUIRES" => {
     "Crypt::OpenSSL::Guess" => 0,
+    "File::Spec::Functions" => 0,
     "File::Which" => 0,
     "Test::Exception" => 0,
     "Test::More" => 0
   },
-  "VERSION" => "0.57",
+  "VERSION" => "0.58",
   "test" => {
     "TESTS" => "t/*.t"
   }
@@ -62,6 +63,7 @@ my %FallbackPrereqs = (
   "CryptX" => "0.036",
   "Digest::SHA" => 0,
   "Encode" => 0,
+  "File::Spec::Functions" => 0,
   "File::Which" => 0,
   "MIME::Base64" => 0,
   "Test::Exception" => 0,

--- a/README
+++ b/README
@@ -3,7 +3,7 @@ NAME
     Signatures
 
 VERSION
-    version 0.57
+    version 0.58
 
 SYNOPSIS
        my $xml = '<foo ID="abc">123</foo>';
@@ -127,6 +127,15 @@ USAGE
         the full XML document so is this is true (1) it will not include the
         XML Declaration at the beginning of the signed XML. False (0) or
         undefined returns an XML document starting with the XML Declaration.
+
+    The following options act similar to "xmlsec --id-attr:ID
+    <node-namespace-uri>:<name>"
+
+    ns  A HashRef to namespaces you want to define to select the correct
+        attribute ID on
+
+    id_attr
+        The xpath string you want to sign your XML message on.
 
   METHODS
    new(...)
@@ -300,7 +309,8 @@ COPYRIGHT AND LICENSE
                 2015       Mike Wisener
                 2016       Jeff Fearn
                 2017       Mike Wisener, xmikew
-                2019-2022  Timothy Legge
+                2019-2021  Timothy Legge
+                2022       Timothy Legge, Wesley Schwengle
 
     This is free software; you can redistribute it and/or modify it under
     the same terms as the Perl 5 programming language system itself.

--- a/cpanfile
+++ b/cpanfile
@@ -23,6 +23,7 @@ requires "warnings" => "0";
 
 on 'test' => sub {
   requires "Crypt::OpenSSL::Guess" => "0";
+  requires "File::Spec::Functions" => "0";
   requires "File::Which" => "0";
   requires "Test::Exception" => "0";
   requires "Test::More" => "0";

--- a/t/008_sign_saml.t
+++ b/t/008_sign_saml.t
@@ -36,6 +36,34 @@ ok( close XML, "DSA: Signed t/dsa.xml written Sucessfully");
 my $dsaret = $dsasig->verify($dsa_signed_xml);
 ok($dsaret, "XML:Sig DSA: Verifed Successfully");
 
+# SAML metadata
+my $md = slurp_file(catfile(qw(t unsigned saml_metadata.xml)));
+my $signed = XML::Sig->new(
+    {
+        x509 => 1,
+        key  => 't/rsa.private.key',
+        cert => 't/rsa.cert.pem',
+        # The syntax is similar to xmlsec: --id-attr:ID urn:...:EntityDescriptor
+        ns   => { md => 'urn:oasis:names:tc:SAML:2.0:metadata' },
+        id_attr => '/md:EntityDescriptor[@ID]',
+    }
+)->sign($md);
+
+my $xp = XML::LibXML::XPathContext->new(
+    XML::LibXML->load_xml(string => $signed)
+);
+
+my %ns = (
+    md => 'urn:oasis:names:tc:SAML:2.0:metadata',
+    ds => 'http://www.w3.org/2000/09/xmldsig#'
+);
+$xp->registerNs($_, $ns{$_}) foreach keys %ns;
+
+my $nodes = $xp->findnodes('//ds:Signature');
+is($nodes->size, 1, "Found only one signature node");
+my $node = $nodes->get_node(1);
+is($node->nodePath, '/md:EntityDescriptor/dsig:Signature', ".. and on the correct node path");
+
 SKIP: {
     skip "xmlsec1 not installed", 4 unless which('xmlsec1');
 

--- a/t/unsigned/saml_metadata.xml
+++ b/t/unsigned/saml_metadata.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="http://localhost:3000" ID="_8f32b973-729a-48fd-9275-0887f06e1cc8">
+  <md:SPSSODescriptor ID="NETSAML2_1c3b4c4d82aad0d9ecc41e400ef4079e" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" AuthnRequestsSigned="0" WantAssertionsSigned="0" errorURL="http://localhost:3000/error">
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo>
+        <ds:X509Data>
+          <ds:X509Certificate>
+          MIIDFTCCAf2gAwIBAgIBATANBgkqhkiG9w0BAQUFADA3MQswCQYDVQQGEwJVUzEO
+          MAwGA1UECgwFbG9jYWwxCzAJBgNVBAsMAmN0MQswCQYDVQQDDAJDQTAeFw0xMDEw
+          MDYxMjM4MTRaFw0xMTEwMDYxMjM4MTRaMFcxCzAJBgNVBAYTAlVTMQ4wDAYDVQQK
+          DAVsb2NhbDELMAkGA1UECwwCY3QxDTALBgNVBAMMBHNhbWwxHDAaBgkqhkiG9w0B
+          CQEWDXNhbWxAY3QubG9jYWwwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMhu
+          pJZpvu1m6ys+IrWrm3pK+onwRAYCyrgQ0RyK2cHbVLFbjBqTjKnt+PiVbnZPZUTs
+          tkV9oijZGQvaMy9ingJursICUQzmOfYRDm4s9gFJJOHUGYnItRhp4uj3EoWWyX8I
+          6Mr+g3/vNgNFvD5S9L7Hk1mSw8SnPlblZAWlFUwXAgMBAAGjgY8wgYwwDAYDVR0T
+          AQH/BAIwADAxBglghkgBhvhCAQ0EJBYiUnVieS9PcGVuU1NMIEdlbmVyYXRlZCBD
+          ZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQUGy/iPd7PVObrF+lK4+ZShcbStLYwCwYDVR0P
+          BAQDAgXgMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDBDANBgkqhkiG9w0B
+          AQUFAAOCAQEAYoYq3Rc6jC7f8DnKxDHntHxH91F5mfp8Y3j7ALcRG/mrzkMhvxU2
+          O2qmh4aHzZBoY1EU9VjrVgyPJPAjFQVC+OjIE46Gavh5wobzYmVGeFLOa9NhPv50
+          h3EOw1eCda3VwcvStWw1OhT8cpEGqgJJVAcjwcm4VBtWjodxRn3E4zBr/xxzR1HU
+          ISvnu1/xomsSS+aenG5toWmhoJIKFbfhQkpnBlgGD5+12Cxn2jHpgv15262ZZIJS
+          WPp/0bQqdAAUzkJZPpUGUN1sTXPJexYT6na7XvLd6mvO1g+WDk6aZnW/zcT3T9tL
+          Iavyic/p4gZtXckweq+VTn9CdZp6ZTQtVw==
+          </ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:SingleLogoutService Location="http://localhost:3000/slo-soap" Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://localhost:3000/sls-redirect-response"/>
+    <md:SingleLogoutService Location="http://localhost:3000/sls-post-response" Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" index="1" isDefault="true" Location="http://localhost:3000/consumer-post"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" index="2" isDefault="false" Location="http://localhost:3000/consumer-artifact"/>
+  </md:SPSSODescriptor>
+  <md:Organization>
+    <md:OrganizationName xml:lang="en">Net::SAML2 Saml2Test</md:OrganizationName>
+    <md:OrganizationDisplayName xml:lang="en">Saml2Test app for Net::SAML2</md:OrganizationDisplayName>
+    <md:OrganizationURL xml:lang="en">http://www.example.com</md:OrganizationURL>
+  </md:Organization>
+  <md:ContactPerson contactType="other">
+    <md:Company>Saml2Test app for Net::SAML2</md:Company>
+    <md:EmailAddress>saml2test@example.com</md:EmailAddress>
+  </md:ContactPerson>
+</md:EntityDescriptor>


### PR DESCRIPTION
You now need to instantiate XML::Sig in a way that looks a bit similar to xmlsec:

    --id-attr:ID urn:...:EntityDescriptor

became:

    XML::Sig->new(
        # other options here
        ns   => { md => 'urn:oasis:names:tc:SAML:2.0:metadata' },
        id_attr => '/md:EntityDescriptor[@ID]',
    );

Signed-off-by: Wesley Schwengle <wesley@opndev.io>