### PR TITLE
Cleanup dist.ini: AutoPrereq catches most of the deps

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -3,7 +3,7 @@ dev
 XML-Sig*
 MANIFEST.SKIP
 MANIFEST.bak
-^*~$
+^.*~$
 ^Makefile$
 t/010_debug_xmlsec.t
 MYMETA.*

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -43,7 +43,7 @@ my %WriteMakefileArgs = (
     "Test::Exception" => 0,
     "Test::More" => 0
   },
-  "VERSION" => "0.58",
+  "VERSION" => "0.59",
   "test" => {
     "TESTS" => "t/*.t"
   }

--- a/README
+++ b/README
@@ -3,7 +3,7 @@ NAME
     Signatures
 
 VERSION
-    version 0.58
+    version 0.59
 
 SYNOPSIS
        my $xml = '<foo ID="abc">123</foo>';

--- a/dist.ini
+++ b/dist.ini
@@ -20,27 +20,12 @@ contributor = Timothy Legge <timlegge@gmail.com>
 
 [AutoPrereqs]
 skips = Crypt::PK::ECC
+
 [Prereqs / RuntimeRequires]
 perl = 5.008
-base = 0
-Class::Accessor = 0
-constant = 0
 Crypt::OpenSSL::Bignum = 0
 Crypt::OpenSSL::DSA = 0.20
-Crypt::OpenSSL::RSA = 0
-Crypt::OpenSSL::X509 = 0
 CryptX = 0.036
-Digest::SHA = 0
-Encode = 0
-MIME::Base64 = 0
-URI = 0
-XML::LibXML = 0
-
-[Prereqs / TestRequires]
-Crypt::OpenSSL::Guess = 0
-File::Which = 0
-Test::Exception = 0
-Test::More = 0
 
 [PruneCruft]
 [ManifestSkip]


### PR DESCRIPTION
Fix wildcard issue from MANIFEST.SKIP, the regexp gave too many errors:

^* matches null string many times in regex; marked by <-- HERE in
m/(?:dev)|(?:.git*)|(?:XML-Sig*)|(?:MANIFEST.SKIP)|(?:MANIFEST.bak)|(?:^* <--
HERE ~$)|(?:^Makefile$)|(?:t/010_debug_xmlsec.t)|(?:MYMETA.*)/ at
/usr/share/perl/5.34/ExtUtils/Manifest.pm line 440.

Signed-off-by: Wesley Schwengle <wesley@opndev.io>