### PR TITLE
Skip xmlsec1 tests for sha1 digests or signature algorithms if sha1 i…

### DIFF
--- a/t/008_sign_saml.t
+++ b/t/008_sign_saml.t
@@ -32,6 +32,9 @@ foreach my $key ('t/dsa.private-2048.key', 't/dsa.private-3072.key', 't/dsa.priv
     SKIP: {
         skip "xmlsec1 not installed", 1 unless $xmlsec->{installed};
 
+        skip "xmlsec1 no sha1 support", 1
+            if ($dsasig->{ sig_hash } eq 'sha1' and $xmlsec->{sha1_support} ne 1);
+
         # Try whether xmlsec is correctly installed which
         # doesn't seem to be the case on every cpan testing machine
 
@@ -58,6 +61,10 @@ foreach my $key ('t/dsa.private-2048.key', 't/dsa.private-3072.key', 't/dsa.priv
     my $key = 't/dsa.public.pem';
     SKIP: {
         skip "xmlsec1 not installed", 1 unless $xmlsec->{installed};
+
+        skip "xmlsec1 no sha1 support", 1
+            if ($xmlsec1_dsasig->{ sig_hash } eq 'sha1' and $xmlsec->{sha1_support} ne 1);
+
         test_xmlsec1_ok(
             "DSA verify XML:Sig signed with $key: xmlsec1 Response is OK",
             $xml, qw(--verify --id-attr:ID "ArtifactResolve"));

--- a/t/011-sign_multiple_sections.t
+++ b/t/011-sign_multiple_sections.t
@@ -56,6 +56,9 @@ ok($dsaret, "XML:Sig DSA: Verifed Successfully");
 SKIP: {
     skip "xmlsec1 not installed", 1 unless $xmlsec->{installed};
 
+    skip "xmlsec1 no sha1 support", 1
+        if ($dsasig->{ sig_hash } eq 'sha1' and $xmlsec->{sha1_support} ne 1);
+
     test_xmlsec1_ok(
         "DSA verify XML:Sig signed: xmlsec1 Response is OK",
         $dsa_signed_xml,

--- a/t/016-SigningAlgorithms.t
+++ b/t/016-SigningAlgorithms.t
@@ -25,6 +25,10 @@ foreach my $alg (@hash_alg) {
 
     SKIP: {
         skip "xmlsec1 not installed", 1 unless $xmlsec->{installed};
+
+        skip "xmlsec1 no sha1 support", 1
+            if ($sig->{ sig_hash } eq 'sha1' and $xmlsec->{sha1_support} ne 1);
+
         test_xmlsec1_ok("Verified by xmlsec1",
             $signed, qw(--verify --id-attr:ID "foo"));
     }

--- a/t/018-DigestSignatureAlgorithms.t
+++ b/t/018-DigestSignatureAlgorithms.t
@@ -25,6 +25,10 @@ foreach my $key ('t/dsa.private.key', 't/dsa.private-2048.key', 't/dsa.private-3
 
         SKIP: {
             skip "xmlsec1 not installed", 1 unless $xmlsec->{installed};
+
+            skip "xmlsec1 no sha1 support", 1
+                if (($digalg eq 'sha1' or $sig->{ sig_hash } eq 'sha1') and $xmlsec->{sha1_support} ne 1);
+
             skip "xmlsec1 does not support ecdsa-ripemd160", 1 if (! $xmlsec->{ripemd160} and
                 $sig->{sig_hash} eq 'ripemd160');
             skip "OpenSSL version 3.0.0 through 3.0.7 do not support ripemd160", 1
@@ -58,6 +62,9 @@ foreach my $key ('t/dsa.private.key', 't/dsa.private-2048.key', 't/dsa.private-3
         SKIP: {
 
             skip "xmlsec1 not installed", 1 unless $xmlsec->{installed};
+
+            skip "xmlsec1 no sha1 support", 1
+                if (($digalg eq 'sha1' or $sig->{ sig_hash } eq 'sha1') and $xmlsec->{sha1_support} ne 1);
 
             skip "xmlsec1 does not support ecdsa-ripemd160", 1 if (! $xmlsec->{ripemd160} and
                 $sig->{sig_hash} eq 'ripemd160');
@@ -100,8 +107,12 @@ foreach my $sigalg (@hash) {
         SKIP: {
             skip "xmlsec1 not installed", 1 unless $xmlsec->{installed};
 
-            skip "xmlsec1 does not support ecdsa-ripemd160", 1 if (! $xmlsec->{ripemd160} and
-                $sig->{sig_hash} eq 'ripemd160');
+            skip "xmlsec1 no sha1 support", 1
+                if (($digalg eq 'sha1' or $sigalg eq 'sha1') and
+                    $xmlsec->{sha1_support} ne 1);
+
+            skip "xmlsec1 no sha1 support", 1
+                if ($sig->{ sig_hash } eq 'sha1' and $xmlsec->{sha1_support} ne 1);
 
             skip "OpenSSL version 3.0.0 through 3.0.7 do not support ripemd160", 1
                 if ( ! $openssl->{ripemd160} and
@@ -140,6 +151,9 @@ foreach my $sigalg (@hash) {
 
         SKIP: {
             skip "xmlsec1 not installed", 1 unless $xmlsec->{installed};
+
+            skip "xmlsec1 no sha1 support", 1
+                if (($digalg eq 'sha1' or $sig->{ sig_hash } eq 'sha1') and $xmlsec->{sha1_support} ne 1);
 
             skip "xmlsec1 does not support ecdsa-ripemd160", 1 if (! $xmlsec->{ripemd160} and
                 $sig->{sig_hash} eq 'ripemd160');
@@ -180,6 +194,9 @@ foreach my $sigalg (@hash) {
 
         SKIP: {
             skip "xmlsec1 not installed", 1 unless $xmlsec->{installed};
+
+            skip "xmlsec1 no sha1 support", 1
+                if (($digalg eq 'sha1' or $sig->{ sig_hash } eq 'sha1') and $xmlsec->{sha1_support} ne 1);
 
             skip "xmlsec1 does not support ecdsa-ripemd160", 1 if (! $xmlsec->{ripemd160} and
                 $sig->{sig_hash} eq 'ripemd160');

--- a/t/019_dsakeys.t
+++ b/t/019_dsakeys.t
@@ -21,6 +21,9 @@ ok($signed, "XML Signed Sucessfully using DSA key");
 SKIP: {
     skip "xmlsec1 not installed", 1 unless $xmlsec->{installed};
 
+    skip "xmlsec1 no sha1 support", 1
+        if (($sig->{ sig_hash } eq 'sha1') and $xmlsec->{sha1_support} ne 1);
+
     test_xmlsec1_ok(
         "verified using xmlsec1 and X509Certificate", $signed, qw(
             --verify --pubkey-cert-pem t/dsa.public.pem

--- a/t/lib/Test/XML/Sig/Util.pm
+++ b/t/lib/Test/XML/Sig/Util.pm
@@ -84,6 +84,10 @@ sub get_xmlsec_features {
     my ($cmd, $ver, $engine) = split / /, (`xmlsec1 --version`);
     my ($major, $minor, $patch) = split /\./, $ver;
 
+    my $transforms = `xmlsec1 --list-transforms`;
+    my $sha1_support = 0;
+    $sha1_support = 1 if ($transforms =~ /\bsha1\b/mg);
+
     my %xmlsec = (
                     installed   => 1,
                     major       => $major,
@@ -93,6 +97,7 @@ sub get_xmlsec_features {
                     ripemd160   => ($major >= 1 and $minor >= 3) ? 1 : 0,
                     aes_gcm     => ($major <= 1 and $minor <= 2 and $patch <= 27) ? 0 : 1,
                     lax_key_search => ($major >= 1 and $minor >= 3) ? 1 : 0,
+                    sha1_support => $sha1_support,
                 );
     return \%xmlsec;
 }


### PR DESCRIPTION
 Skip xmlsec1 tests for sha1 digests or signature algorithms if sha1 is disabled

A user reported the issue directly and it affects Rockyy Linux9 and RHEL9

I am tempted to simply skip the xmlsec based tests if it AUTHOR_TESTING is not set.
